### PR TITLE
feat: add `transportId` param to `shouldSendToLogger` plugin callback

### DIFF
--- a/.changeset/many-otters-melt.md
+++ b/.changeset/many-otters-melt.md
@@ -1,0 +1,6 @@
+---
+"loglayer": patch
+"@loglayer/plugin": patch
+---
+
+Add `transportId` parameter to plugin `shouldSendToLogger` call

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ on:
       - opened
       - reopened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - 'packages/**'
 
 jobs:
   lint:
@@ -28,7 +28,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: pnpm install --frozen-lockfile
 
       - name: Build workspace packages
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - 'packages/**'
 
 env:
   PNPM_CACHE_FOLDER: .pnpm-store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - opened
       - reopened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - 'packages/**'
 
 jobs:
   test:
@@ -30,19 +30,11 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: pnpm install --frozen-lockfile
 
       - name: Build workspace packages
         run: pnpm build
 
-      - name: Branch Information
-        run: |
-          echo "Git Branch: $(git branch)"
-          echo "Git Log: $(git log --oneline)"
-          echo "HEAD SHA: $(git rev-parse HEAD)"
-          echo "HEAD^1 SHA: $(git rev-parse HEAD^1)"
-          echo "Git Diff: $(git diff HEAD^1)"
-
-      - name: Run Package(s) Tests
+      - name: Run Package Tests
         run: |
           pnpm run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 - Commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
   * The commit message should be in the format `<type>(<scope>): <description>`. The `scope` is optional. The description must be lowercased.
-- This project uses [changeset](https://github.com/changesets/changesets) for managing releases. Use the `add-changeset` command to add a changeset for your changes.
+- This project uses [changeset](https://github.com/changesets/changesets) for managing releases. Use the `pnpm run add-changeset` command to add a changeset for your changes.
   * Fixes should be added to the `patch` category.
   * New features should be added to the `minor` category.
   * Breaking changes should be added to the `major` category.

--- a/docs/src/plugins/creating.md
+++ b/docs/src/plugins/creating.md
@@ -111,6 +111,7 @@ shouldSendToLogger?(params: PluginShouldSendToLoggerParams): boolean
 **Parameters:**
 ```typescript
 interface PluginShouldSendToLoggerParams {
+  transportId?: string;        // ID of the transport that will send the log
   messages: any[];              // Message data that is copied from the original
   logLevel: LogLevel;          // Log level of the message
   data?: Record<string, any>;  // The object containing metadata / context / error data
@@ -130,6 +131,22 @@ const productionFilterPlugin = {
     if (logLevel === 'error') {
       return !isRateLimited('error-logs')
     }
+    return true
+  }
+}
+```
+
+**Example:**
+```typescript
+
+const productionFilterPlugin = {
+  id: 'production-filter',
+  shouldSendToLogger: ({ transportId, logLevel, data }) => {
+    // don't send logs if the transportId is 'console'
+    if (transportId === 'console') {
+      return false
+    }
+    
     return true
   }
 }

--- a/packages/core/loglayer/LICENSE
+++ b/packages/core/loglayer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Theo Gravity
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/loglayer/src/LogLayer.ts
+++ b/packages/core/loglayer/src/LogLayer.ts
@@ -451,20 +451,21 @@ export class LogLayer implements ILogLayer {
       });
     }
 
-    if (this.pluginManager.hasPlugins(PluginCallbackType.shouldSendToLogger)) {
-      const shouldSend = this.pluginManager.runShouldSendToLogger({
-        messages: [...params],
-        data: hasObjData ? d : undefined,
-        logLevel,
-      });
-
-      if (!shouldSend) {
-        return;
-      }
-    }
-
     if (Array.isArray(this._config.transport)) {
       for (const transport of this._config.transport) {
+        if (this.pluginManager.hasPlugins(PluginCallbackType.shouldSendToLogger)) {
+          const shouldSend = this.pluginManager.runShouldSendToLogger({
+            messages: [...params],
+            data: hasObjData ? d : undefined,
+            logLevel,
+            transportId: transport.id,
+          });
+
+          if (!shouldSend) {
+            continue;
+          }
+        }
+
         transport._sendToLogger({
           logLevel,
           messages: [...params],
@@ -473,6 +474,19 @@ export class LogLayer implements ILogLayer {
         });
       }
     } else {
+      if (this.pluginManager.hasPlugins(PluginCallbackType.shouldSendToLogger)) {
+        const shouldSend = this.pluginManager.runShouldSendToLogger({
+          messages: [...params],
+          data: hasObjData ? d : undefined,
+          logLevel,
+          transportId: this._config.transport.id,
+        });
+
+        if (!shouldSend) {
+          return;
+        }
+      }
+
       this._config.transport._sendToLogger({
         logLevel,
         messages: [...params],

--- a/packages/core/plugin/src/types.ts
+++ b/packages/core/plugin/src/types.ts
@@ -16,6 +16,10 @@ export type PluginBeforeDataOutFn = (params: PluginBeforeDataOutParams) => Recor
 
 export interface PluginShouldSendToLoggerParams {
   /**
+   * Unique identifier for the transport. Can be used to not send to a specific transport.
+   */
+  transportId?: string;
+  /**
    * Message data that is copied from the original.
    */
   messages: any[];

--- a/turbo.json
+++ b/turbo.json
@@ -9,15 +9,12 @@
       "persistent": true
     },
     "build:dev": {
-      "cache": false
+      "cache": false,
+        "dependsOn": ["^build:dev"]
     },
     "build": {
-      "dependsOn": ["lint", "^build"],
-      "cache": true,
-      "inputs": [
-        "$TURBO_DEFAULT$"
-      ],
-      "outputs": ["dist/**"]
+      "cache": false,
+      "dependsOn": ["^build"]
     },
     "verify-types": {},
     "lint": {},


### PR DESCRIPTION
This adds the `transportId` param to the `shouldSendToLogger` plugin callback method. This allows one to prevent specific log entries from being shipped to a specific transport.