### PR TITLE
fix(loglayer): fixes import issues caused by exporting LogLevel from multiple packages

### DIFF
--- a/.changeset/sour-tips-dream.md
+++ b/.changeset/sour-tips-dream.md
@@ -1,0 +1,5 @@
+---
+"loglayer": patch
+---
+
+Fixes an import issue caused by exporting LogLevel from multiple packages.

--- a/packages/core/loglayer/src/TestLoggingLibrary.ts
+++ b/packages/core/loglayer/src/TestLoggingLibrary.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from "@loglayer/shared";
+import { LogLevel, type LogLevelType } from "@loglayer/shared";
 
 /**
  * A test logging library that can be used to test LogLayer plugins and transports.
@@ -9,7 +9,7 @@ export class TestLoggingLibrary {
    * An array of log lines that have been logged.
    */
   lines: Array<{
-    level: LogLevel;
+    level: LogLevelType;
     data: any[];
   }>;
 

--- a/packages/core/loglayer/src/index.ts
+++ b/packages/core/loglayer/src/index.ts
@@ -2,8 +2,26 @@ export { LogLayer } from "./LogLayer.js";
 export { MockLogLayer } from "./MockLogLayer.js";
 export { MockLogBuilder } from "./MockLogBuilder.js";
 export * from "./types/index.js";
-export type { ErrorOnlyOpts, ILogLayer, ILogBuilder } from "@loglayer/shared";
 export { ConsoleTransport } from "./transports/ConsoleTransport.js";
 export { TestLoggingLibrary } from "./TestLoggingLibrary.js";
 export { TestTransport } from "./transports/TestTransport.js";
-export * from "@loglayer/plugin";
+
+export type {
+  PluginBeforeDataOutFn,
+  PluginShouldSendToLoggerFn,
+  PluginBeforeMessageOutFn,
+  PluginOnMetadataCalledFn,
+  PluginOnContextCalledFn,
+} from "@loglayer/plugin";
+
+export { PluginCallbackType } from "@loglayer/plugin";
+
+export type {
+  LogLevelType,
+  ErrorOnlyOpts,
+  ILogLayer,
+  ILogBuilder,
+  LogLayerTransport,
+} from "@loglayer/shared";
+
+export { LogLevel } from "@loglayer/shared";

--- a/packages/core/loglayer/src/transports/ConsoleTransport.ts
+++ b/packages/core/loglayer/src/transports/ConsoleTransport.ts
@@ -1,5 +1,6 @@
+import { LogLevel } from "@loglayer/shared";
 import type { LogLayerTransportConfig, LogLayerTransportParams } from "@loglayer/transport";
-import { BaseTransport, LogLevel } from "@loglayer/transport";
+import { BaseTransport } from "@loglayer/transport";
 import { LogLevelPriority } from "@loglayer/transport";
 
 type ConsoleType = typeof console;

--- a/packages/core/loglayer/src/transports/TestTransport.ts
+++ b/packages/core/loglayer/src/transports/TestTransport.ts
@@ -1,4 +1,5 @@
-import { BaseTransport, type LogLayerTransportParams, LogLevel } from "@loglayer/transport";
+import { LogLevel } from "@loglayer/shared";
+import { BaseTransport, type LogLayerTransportParams } from "@loglayer/transport";
 import type { TestLoggingLibrary } from "../TestLoggingLibrary.js";
 
 /**

--- a/packages/core/loglayer/src/types/index.ts
+++ b/packages/core/loglayer/src/types/index.ts
@@ -1,15 +1,6 @@
 import type { LogLayerPlugin } from "@loglayer/plugin";
 import type { LogLayerTransport } from "@loglayer/transport";
 
-export {
-  LogLevel,
-  type LogLevelType,
-  type ErrorOnlyOpts,
-  type ILogLayer,
-  type ILogBuilder,
-  type LogLayerTransport,
-} from "@loglayer/shared";
-
 export type ErrorSerializerType = (err: any) => Record<string, any> | string;
 
 /**
@@ -22,7 +13,7 @@ export interface LogLayerConfig {
    */
   prefix?: string;
   /**
-   * Set to false to drop all log input and stop sending to the logging
+   * Set false to drop all log input and stop sending to the logging
    * library.
    *
    * Can be re-enabled with `enableLogging()`.
@@ -72,7 +63,7 @@ export interface LogLayerConfig {
    */
   copyMsgOnOnlyError?: boolean;
   /**
-   * If set to true, the error will be included as part of metadata instead of
+   * If set to true, the error will be included as part of metadata instead
    * of the root of the log data.
    *
    * metadataFieldName must be set to true for this to work.


### PR DESCRIPTION
Addresses this issue by being more explicit around `export from` statements, and de-duping how we export / import the `LogLevel` enum.

```
> node dist/index.js

node_modules/.pnpm/loglayer@6.4.0/node_modules/loglayer/dist/index.cjs:1241
exports.ConsoleTransport = ConsoleTransport; exports.LogLayer = LogLayer; exports.LogLevel = _shared.LogLevel; exports.MockLogBuilder = MockLogBuilder; exports.MockLogLayer = MockLogLayer; exports.TestLoggingLibrary = TestLoggingLibrary; exports.TestTransport = TestTransport;
                                                                                           ^

TypeError: Cannot set property LogLevel of #<Object> which has only a getter
    at Object.<anonymous> (/node_modules/.pnpm/loglayer@6.4.0/node_modules/loglayer/dist/index.cjs:1241:92)
```