### PR TITLE
feat(@loglayer/transport-google-cloud-logging): allow specifying `LogEntry` metadata using `withMetadata()` / `withContext()`

### DIFF
--- a/.changeset/many-dolls-marry.md
+++ b/.changeset/many-dolls-marry.md
@@ -1,5 +1,0 @@
----
-"@loglayer/transport-google-cloud-logging": major
----
-
-Allow specifying `LogEntry` metadata using `withMetadata()` / `withContext()`

--- a/.changeset/many-dolls-marry.md
+++ b/.changeset/many-dolls-marry.md
@@ -1,0 +1,5 @@
+---
+"@loglayer/transport-google-cloud-logging": major
+---
+
+Allow specifying `LogEntry` metadata using `withMetadata()` / `withContext()`

--- a/.changeset/plain-bobcats-find.md
+++ b/.changeset/plain-bobcats-find.md
@@ -1,0 +1,5 @@
+---
+"@loglayer/transport-google-cloud-logging": minor
+---
+
+Add `metadataBehavior` config for specifying `LogEntry` metadata using `withMetadata()` / `withContext()`

--- a/.changeset/plain-bobcats-find.md
+++ b/.changeset/plain-bobcats-find.md
@@ -2,4 +2,4 @@
 "@loglayer/transport-google-cloud-logging": minor
 ---
 
-Add `metadataBehavior` config for specifying `LogEntry` metadata using `withMetadata()` / `withContext()`
+Add `rootLevelMetadataFields` config for specifying `LogEntry` metadata using `withMetadata()` / `withContext()`

--- a/docs/src/transports/google-cloud-logging.md
+++ b/docs/src/transports/google-cloud-logging.md
@@ -52,8 +52,8 @@ pnpm add @loglayer/transport-google-cloud-logging @google-cloud/logging serializ
 ::: info
 This transport uses `log.entry(metadata, data)` as described in the library documentation.
 
-- The `metadata` portion is not the data from `withMetadata()` or `withContext()`. See the `rootLevelData` option
-  for this transport on how to modify this value.
+- The `metadata` portion is the data from `withMetadata()` or `withContext()`. Custom fields not known by Google Cloud Logging will end up in the `data` portion. 
+- See the `rootLevelData` option for this transport to specify default metadata.
 - The `data` portion is actually the `jsonPayload` is what the transport uses for all LogLayer data.
 - The message data is stored in `jsonPayload.message`
 

--- a/packages/transports/google-cloud-logging/README.md
+++ b/packages/transports/google-cloud-logging/README.md
@@ -18,7 +18,7 @@ npm install @loglayer/transport-google-cloud-logging @google-cloud/logging seria
 
 This transport uses `log.entry(metadata, data)` as described in the library documentation.
 
-- The `metadata` portion is not the data from `withMetadata()` or `withContext()`. See the `rootLevelData` and `metadataBehavior` options
+- The `metadata` portion is not the data from `withMetadata()` or `withContext()`. See the `rootLevelData` and `rootLevelMetadataFields` options
   for this transport on how to modify this value.
 - The `data` portion is actually the `jsonPayload` is what the transport uses for all LogLayer data.
 - The message data is stored in `jsonPayload.message`
@@ -82,17 +82,17 @@ const logger = new LogLayer({
 });
 ```
 
-### `metadataBehavior`
+### `rootLevelMetadataFields`
 
-By default, `withMetadata()` fields are forwarded as part of `jsonPayload` of the [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). 
+By default, `withMetadata()` fields are forwarded as part of `jsonPayload` of the [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
 
-When set to `"promote"`, metadata will be merged with at the top level with `rootLevelData`. Metadata fields that aren't valid log entry fields are still included in `jsonPayload`.
+The `rootLevelMetadataFields` option accepts an array of field names to pluck from metadata and shallow merge with `rootLevelData`. This allows you to dynamically specify the metadata portion of a log entry.
 
 ```typescript
 const logger = new LogLayer({
   transport: new GoogleCloudLoggingTransport({
     logger: log,
-    metadataBehavior: "promote",
+    rootLevelMetadataFields: ["labels"],
     rootLevelData: {
       labels: {
         environment: "production",
@@ -107,6 +107,29 @@ const logger = new LogLayer({
 logger
   .withMetadata({ labels: { location: "east" }, customField: "example" })
   .info("example")
+```
+
+To allow mapping to every supported `LogEntry` metadata field, the following list is recommended:
+
+```typescript
+const logger = new LogLayer({
+  transport: new GoogleCloudLoggingTransport({
+    logger: log,
+    rootLevelMetadataFields: [
+      "logName",
+      "resource",
+      "insertId",
+      "httpRequest",
+      "labels",
+      "operation",
+      "trace",
+      "spanId",
+      "traceSampled",
+      "sourceLocation",
+      "split",
+    ],
+  }),
+});
 ```
 
 ## Log Level Mapping

--- a/packages/transports/google-cloud-logging/README.md
+++ b/packages/transports/google-cloud-logging/README.md
@@ -18,8 +18,8 @@ npm install @loglayer/transport-google-cloud-logging @google-cloud/logging seria
 
 This transport uses `log.entry(metadata, data)` as described in the library documentation.
 
-- The `metadata` portion is not the data from `withMetadata()` or `withContext()`. See the `rootLevelData` option
-  for this transport on how to modify this value.
+- The `metadata` portion is the data from `withMetadata()` or `withContext()`. Custom fields not known by Google Cloud Logging will end up in the `data` portion. 
+- See the `rootLevelData` option for this transport to specify default metadata.
 - The `data` portion is actually the `jsonPayload` is what the transport uses for all LogLayer data.
 - The message data is stored in `jsonPayload.message`
 
@@ -54,8 +54,8 @@ logger.info("Hello from Cloud Run!");
 
 ### `rootLevelData`
 
-The root level data to include for all log entries. 
-This is not the same as using `withContext()`, which would be included as part of the `jsonPayload`.
+The root level metadata to include for all log entries. 
+This value is merged with metadata provided using `withContext()`.
 
 The `rootLevelData` option accepts any valid [Google Cloud LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) 
 fields except for `severity`, `timestamp`, and `jsonPayload` which are managed by the transport.

--- a/packages/transports/google-cloud-logging/README.md
+++ b/packages/transports/google-cloud-logging/README.md
@@ -18,8 +18,8 @@ npm install @loglayer/transport-google-cloud-logging @google-cloud/logging seria
 
 This transport uses `log.entry(metadata, data)` as described in the library documentation.
 
-- The `metadata` portion is the data from `withMetadata()` or `withContext()`. Custom fields not known by Google Cloud Logging will end up in the `data` portion. 
-- See the `rootLevelData` option for this transport to specify default metadata.
+- The `metadata` portion is not the data from `withMetadata()` or `withContext()`. See the `rootLevelData` and `metadataBehavior` options
+  for this transport on how to modify this value.
 - The `data` portion is actually the `jsonPayload` is what the transport uses for all LogLayer data.
 - The message data is stored in `jsonPayload.message`
 
@@ -80,6 +80,33 @@ const logger = new LogLayer({
     },
   }),
 });
+```
+
+### `metadataBehavior`
+
+By default, `withMetadata()` fields are forwarded as part of `jsonPayload` of the [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). 
+
+When set to `"promote"`, metadata will be merged with at the top level with `rootLevelData`. Metadata fields that aren't valid log entry fields are still included in `jsonPayload`.
+
+```typescript
+const logger = new LogLayer({
+  transport: new GoogleCloudLoggingTransport({
+    logger: log,
+    metadataBehavior: "promote",
+    rootLevelData: {
+      labels: {
+        environment: "production",
+        location: "west",
+      },
+    },
+  }),
+});
+
+// This will overwrite `labels` in root level data.
+// `customField` is still sent as part of `jsonPayload`.
+logger
+  .withMetadata({ labels: { location: "east" }, customField: "example" })
+  .info("example")
 ```
 
 ## Log Level Mapping

--- a/packages/transports/google-cloud-logging/src/GoogleCloudLoggingTransport.ts
+++ b/packages/transports/google-cloud-logging/src/GoogleCloudLoggingTransport.ts
@@ -9,7 +9,10 @@ export interface GoogleCloudLoggingTransportConfig extends LogLayerTransportConf
    * "severity", "timestamp" and "jsonPayload" are already populated by the transport.
    * @see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
    */
-  rootLevelData?: Omit<LogEntry, "severity" | "timestamp" | "jsonPayload">;
+  rootLevelData?: Omit<
+    LogEntry,
+    "severity" | "timestamp" | "receiveTimestamp" | "jsonPayload" | "textPayload" | "protoPayload"
+  >;
 
   /**
    * Minimum log level to process. Defaults to "trace"
@@ -17,9 +20,25 @@ export interface GoogleCloudLoggingTransportConfig extends LogLayerTransportConf
   level?: LogLevelType;
 }
 
+type LogEntryField = keyof GoogleCloudLoggingTransport["rootLevelData"];
+
 export class GoogleCloudLoggingTransport extends BaseTransport<Log> {
-  private rootLevelData: Omit<LogEntry, "severity" | "timestamp" | "jsonPayload">;
+  private rootLevelData: GoogleCloudLoggingTransportConfig["rootLevelData"];
   private level: LogLevelType;
+
+  private logEntryKeys: Set<LogEntryField> = new Set([
+    "logName",
+    "resource",
+    "insertId",
+    "httpRequest",
+    "labels",
+    "operation",
+    "trace",
+    "spanId",
+    "traceSampled",
+    "sourceLocation",
+    "split",
+  ]);
 
   constructor(config: GoogleCloudLoggingTransportConfig) {
     super(config);
@@ -46,20 +65,38 @@ export class GoogleCloudLoggingTransport extends BaseTransport<Log> {
     }
   }
 
+  private extractLogEntryFields(data: Record<string, unknown>) {
+    const keys = Object.keys(data);
+    const metadata: Record<string, unknown> = {};
+
+    for (const key of keys) {
+      if (this.logEntryKeys.has(key as LogEntryField)) {
+        metadata[key] = data[key];
+        delete data[key];
+      }
+    }
+
+    return metadata;
+  }
+
   shipToLogger({ data, hasData, logLevel, messages }: LogLayerTransportParams): any[] {
     // Skip if log level is lower priority than configured minimum
     if (LogLevelPriority[logLevel] < LogLevelPriority[this.level]) {
       return [];
     }
 
+    const safeData = data && hasData ? data : {};
+    const metadata = this.extractLogEntryFields(safeData);
+
     const entry = this.logger.entry(
       {
         ...this.rootLevelData,
+        ...metadata,
         severity: this.mapLogLevel(logLevel),
         timestamp: new Date(),
       },
       {
-        ...(data && hasData ? data : {}),
+        ...safeData,
         message: messages.join(" "),
       },
     );

--- a/packages/transports/google-cloud-logging/src/__tests__/GoogleCloudLoggingTransport.test.ts
+++ b/packages/transports/google-cloud-logging/src/__tests__/GoogleCloudLoggingTransport.test.ts
@@ -66,10 +66,56 @@ describe("GoogleCloudLoggingTransport", () => {
   });
 
   describe("metadata handling", () => {
-    it("should include metadata in log entries", () => {
-      const metadata = {
+    it("should include custom metadata under data", () => {
+      const customMetadata = {
         service: "test-service",
         environment: "test",
+      };
+
+      logger.withMetadata(customMetadata).info("test message");
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            severity: "INFO",
+            timestamp: expect.any(Date),
+          }),
+          data: {
+            ...customMetadata,
+            message: "test message",
+          },
+        }),
+      );
+    });
+
+    it("should include known metadata under metadata", () => {
+      const metadata = {
+        logName: "test-log",
+        resource: {
+          type: "global",
+          labels: {
+            project_id: "test-project",
+          },
+        },
+        insertId: "insert-123",
+        httpRequest: {
+          requestMethod: "GET",
+        },
+        labels: {
+          environment: "test",
+        },
+        operation: {
+          id: "operation-123",
+        },
+        trace: "trace-123",
+        spanId: "span-123",
+        traceSampled: true,
+        sourceLocation: {
+          file: "GoogleCloudLoggingTransport.test.ts",
+        },
+        split: {
+          totalSplits: 3,
+        },
       };
 
       logger.withMetadata(metadata).info("test message");
@@ -79,9 +125,9 @@ describe("GoogleCloudLoggingTransport", () => {
           metadata: expect.objectContaining({
             severity: "INFO",
             timestamp: expect.any(Date),
+            ...metadata,
           }),
           data: {
-            ...metadata,
             message: "test message",
           },
         }),

--- a/packages/transports/google-cloud-logging/src/__tests__/GoogleCloudLoggingTransport.test.ts
+++ b/packages/transports/google-cloud-logging/src/__tests__/GoogleCloudLoggingTransport.test.ts
@@ -193,14 +193,14 @@ describe("GoogleCloudLoggingTransport", () => {
         },
       };
 
-      const loggerWithMetadataBehavior = new LogLayer({
+      const loggerWithRootLevelMetadataFields = new LogLayer({
         transport: new GoogleCloudLoggingTransport({
           logger: mockLog,
           rootLevelMetadataFields: [],
         }),
       });
 
-      loggerWithMetadataBehavior.withMetadata(metadata).info("test message");
+      loggerWithRootLevelMetadataFields.withMetadata(metadata).info("test message");
 
       expect(mockWrite).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -247,7 +247,7 @@ describe("GoogleCloudLoggingTransport", () => {
         },
       };
 
-      const loggerWithMetadataBehavior = new LogLayer({
+      const loggerWithRootLevelMetadataFields = new LogLayer({
         transport: new GoogleCloudLoggingTransport({
           logger: mockLog,
           rootLevelMetadataFields: [
@@ -266,7 +266,7 @@ describe("GoogleCloudLoggingTransport", () => {
         }),
       });
 
-      loggerWithMetadataBehavior.withMetadata(metadata).info("test message");
+      loggerWithRootLevelMetadataFields.withMetadata(metadata).info("test message");
 
       const { customField, ...restMetadata } = metadata;
 

--- a/packages/transports/google-cloud-logging/src/__tests__/GoogleCloudLoggingTransport.test.ts
+++ b/packages/transports/google-cloud-logging/src/__tests__/GoogleCloudLoggingTransport.test.ts
@@ -161,8 +161,8 @@ describe("GoogleCloudLoggingTransport", () => {
     });
   });
 
-  describe("metadataBehavior", () => {
-    it("should include known LogEntry fields under data when set to 'jsonPayload'", () => {
+  describe("rootLevelMetadataFields", () => {
+    it("should include all log entry fields under data when 'rootLevelMetadataFields' is empty", () => {
       const metadata = {
         customField: "customValue",
         logName: "test-log",
@@ -196,7 +196,7 @@ describe("GoogleCloudLoggingTransport", () => {
       const loggerWithMetadataBehavior = new LogLayer({
         transport: new GoogleCloudLoggingTransport({
           logger: mockLog,
-          metadataBehavior: "jsonPayload",
+          rootLevelMetadataFields: [],
         }),
       });
 
@@ -216,7 +216,7 @@ describe("GoogleCloudLoggingTransport", () => {
       );
     });
 
-    it("should include known LogEntry fields under metadata when set to 'promote'", () => {
+    it("should include all log entry fields under metadata when specified by 'rootLevelMetadataFields'", () => {
       const metadata = {
         customField: "customValue",
         logName: "test-log",
@@ -250,7 +250,19 @@ describe("GoogleCloudLoggingTransport", () => {
       const loggerWithMetadataBehavior = new LogLayer({
         transport: new GoogleCloudLoggingTransport({
           logger: mockLog,
-          metadataBehavior: "promote",
+          rootLevelMetadataFields: [
+            "logName",
+            "resource",
+            "insertId",
+            "httpRequest",
+            "labels",
+            "operation",
+            "trace",
+            "spanId",
+            "traceSampled",
+            "sourceLocation",
+            "split",
+          ],
         }),
       });
 


### PR DESCRIPTION
Hey! really loving LogLayer, thanks for making it!

### Context

I'd love to use LogLayer for structured logging on Google Cloud. I noticed the Cloud Logging transport doesn't allow passing [`LogEntry`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) fields and instead they must be declared up front with `rootLeveMetadata` - everything goes to `jsonPayload` instead. 

This doesn't work for me (let me know if I'm holding it wrong). I'd like to set those properties dynamically at 'log time' e.g.

```ts
const res = await fetch("https://example.com")

if (!res.ok) {
  log.withMetadata({ httpRequest: res }).info("Request failed")
  // ...
}
```

where `httpRequest` is a standard `LogEntry` field, and won't end up under `jsonPayload`.

### Approach

This PR updates the transport to allow doing the above by plucking known `LogEntry` fields from the data object and passing them as part of the metadata argument instead of data in `log.entry(metadata, data)` e.g.

```ts
const res = await fetch("https://example.com")

if (!res.ok) {
  log.withMetadata({ httpRequest: res, custom: 'hello' }).info("Request failed")
  // ...
}
```

In this example, the transport knows to pass `httpRequest` to metadata, and `custom` to data.

---

I tagged this as a major bump and a breaking change. While nothing should actually break, it will affect how logs are serialized to Cloud Logging; i.e. if you previously used field names that conflict with `LogEntry` fields, they'll no longer end up under `jsonPayload` which might be unexpected.

(if this approach isn't what you had in mind for this transport, I'm happy to iterate or close the PR).