### PR TITLE
fix(loglayer): update ConsoleTransport behavior for lone `levelField`/ `dateField`

### DIFF
--- a/.changeset/plain-days-tickle.md
+++ b/.changeset/plain-days-tickle.md
@@ -1,0 +1,6 @@
+---
+"loglayer": minor
+---
+
+`ConsoleTransport`: Fixes an issue where `levelField` and `dateField` should not affect the output in the same way that `messageField` would. 
+This change brings the behavior to what is described in the documentation for the `ConsoleTransport`.

--- a/docs/src/transports/console.md
+++ b/docs/src/transports/console.md
@@ -56,8 +56,8 @@ None - all parameters are optional.
 | `level` | `"trace" \| "debug" \| "info" \| "warn" \| "error" \| "fatal"` | `"trace"` | Sets the minimum log level to process. Messages with a lower priority level will be ignored |
 | `appendObjectData` | `boolean` | `false` | Controls where object data (metadata, context, errors) appears in the log messages. `false`: Object data appears as the first parameter. `true`: Object data appears as the last parameter. Has no effect if `messageField` is defined |
 | `messageField` | `string` | - | If defined, places the message into the specified field in the log object, joins multi-parameter messages with a space (use the sprintf plugin for formatted messages), and only logs the object to the console |
-| `dateField` | `string` | - | If defined, populates the field with the ISO date. If `dateFn` is defined, will call `dateFn` to derive the date |
-| `levelField` | `string` | - | If defined, populates the field with the log level. If `levelFn` is defined, will call `levelFn` to derive the level |
+| `dateField` | `string` | - | If defined, populates the field with the ISO date and adds it as an additional parameter to the console call. If `dateFn` is defined, will call `dateFn` to derive the date |
+| `levelField` | `string` | - | If defined, populates the field with the log level and adds it as an additional parameter to the console call. If `levelFn` is defined, will call `levelFn` to derive the level |
 | `dateFn` | `() => string \| number` | - | If defined, a function that returns a string or number for the value to be used for the `dateField` |
 | `levelFn` | `(logLevel: LogLevelType) => string \| number` | - | If defined, a function that returns a string or number for a given log level. The input should be the logLevel |
 | `stringify` | `boolean` | `false` | If true, applies JSON.stringify to the structured log output when messageField, dateField, or levelField is defined |
@@ -111,7 +111,7 @@ const log = new LogLayer({
 });
 
 log.info('User logged in');
-// console.info({ timestamp: '2023-12-01T10:30:00.000Z' })
+// console.info('User logged in', { timestamp: '2023-12-01T10:30:00.000Z' })
 ```
 
 #### Level Field
@@ -124,7 +124,7 @@ const log = new LogLayer({
 });
 
 log.warn('User session expired');
-// console.warn({ level: 'warn' })
+// console.warn('User session expired', { level: 'warn' })
 ```
 
 #### Custom Date Function
@@ -138,7 +138,7 @@ const log = new LogLayer({
 });
 
 log.info('User logged in');
-// console.info({ timestamp: 1701437400000 })
+// console.info('User logged in', { timestamp: 1701437400000 })
 ```
 
 #### Custom Level Function
@@ -152,7 +152,7 @@ const log = new LogLayer({
 });
 
 log.warn('User session expired');
-// console.warn({ level: 'WARN' })
+// console.warn('User session expired', { level: 'WARN' })
 ```
 
 #### Numeric Level Mapping
@@ -169,7 +169,7 @@ const log = new LogLayer({
 });
 
 log.error('Database connection failed');
-// console.error({ level: 50 })
+// console.error('Database connection failed', { level: 50 })
 ```
 
 #### Stringify Output

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -7,6 +7,13 @@ description: Learn about the latest features and improvements in LogLayer
 
 - [`loglayer` Changelog](/core-changelogs/loglayer-changelog)
 
+## Oct 21, 2025
+
+`loglayer`:
+
+- `ConsoleTransport`: Fixes an issue where `levelField` and `dateField` should not affect the output in the same way that `messageField` would. 
+This change brings the behavior to what is described in the documentation for the `ConsoleTransport`.
+
 ## Oct 14, 2025
 
 `@loglayer/transport-sentry`:

--- a/packages/core/loglayer/src/transports/ConsoleTransport.ts
+++ b/packages/core/loglayer/src/transports/ConsoleTransport.ts
@@ -82,16 +82,28 @@ export class ConsoleTransport extends BaseTransport<ConsoleType> {
       return;
     }
 
-    if (this.messageField || this.dateField || this.levelField) {
+    if (this.messageField) {
       // Join messages with a space if messageField is defined
-      const messageText = this.messageField ? messages.join(" ") : undefined;
+      const messageText = messages.join(" ");
       const logObject = {
         ...(data || {}),
-        ...(this.messageField && { [this.messageField]: messageText }),
+        [this.messageField]: messageText,
         ...(this.dateField && { [this.dateField]: this.dateFn ? this.dateFn() : new Date().toISOString() }),
         ...(this.levelField && { [this.levelField]: this.levelFn ? this.levelFn(logLevel) : logLevel }),
       };
       messages = [this.stringify ? JSON.stringify(logObject) : logObject];
+    } else if (this.dateField || this.levelField) {
+      // Only dateField or levelField are defined - preserve original messages and add fields as additional parameter
+      const logObject = {
+        ...(data || {}),
+        ...(this.dateField && { [this.dateField]: this.dateFn ? this.dateFn() : new Date().toISOString() }),
+        ...(this.levelField && { [this.levelField]: this.levelFn ? this.levelFn(logLevel) : logLevel }),
+      };
+      if (this.stringify) {
+        messages.push(JSON.stringify(logObject));
+      } else {
+        messages.push(logObject);
+      }
     } else if (data && hasData) {
       if (this.appendObjectData) {
         messages.push(data);

--- a/packages/core/loglayer/src/transports/__tests__/ConsoleTransport.test.ts
+++ b/packages/core/loglayer/src/transports/__tests__/ConsoleTransport.test.ts
@@ -170,8 +170,14 @@ describe("ConsoleTransport", () => {
       });
       const afterDate = new Date().toISOString();
 
-      const call = (mockConsole.info as any).mock.calls[0][0];
-      expect(call).toHaveProperty("timestamp");
+      expect(mockConsole.info).toHaveBeenCalledWith(
+        "test message",
+        expect.objectContaining({
+          timestamp: expect.any(String),
+        }),
+      );
+
+      const call = (mockConsole.info as any).mock.calls[0][1];
       expect(call.timestamp >= beforeDate).toBe(true);
       expect(call.timestamp <= afterDate).toBe(true);
     });
@@ -191,7 +197,7 @@ describe("ConsoleTransport", () => {
       });
 
       expect(dateFn).toHaveBeenCalledOnce();
-      expect(mockConsole.info).toHaveBeenCalledWith({
+      expect(mockConsole.info).toHaveBeenCalledWith("test message", {
         timestamp: customDate,
       });
     });
@@ -211,7 +217,7 @@ describe("ConsoleTransport", () => {
       });
 
       expect(dateFn).toHaveBeenCalledOnce();
-      expect(mockConsole.info).toHaveBeenCalledWith({
+      expect(mockConsole.info).toHaveBeenCalledWith("test message", {
         timestamp: customTimestamp,
       });
     });
@@ -230,10 +236,13 @@ describe("ConsoleTransport", () => {
         hasData: true,
       });
 
-      const call = (mockConsole.info as any).mock.calls[0][0];
-      expect(call).toHaveProperty("user", "john");
-      expect(call).toHaveProperty("timestamp");
-      expect(typeof call.timestamp).toBe("string");
+      expect(mockConsole.info).toHaveBeenCalledWith(
+        "test message",
+        expect.objectContaining({
+          user: "john",
+          timestamp: expect.any(String),
+        }),
+      );
     });
   });
 
@@ -249,7 +258,7 @@ describe("ConsoleTransport", () => {
         messages: ["test message"],
       });
 
-      expect(mockConsole.info).toHaveBeenCalledWith({
+      expect(mockConsole.info).toHaveBeenCalledWith("test message", {
         level: "info",
       });
     });
@@ -268,7 +277,7 @@ describe("ConsoleTransport", () => {
       });
 
       expect(levelFn).toHaveBeenCalledWith("warn");
-      expect(mockConsole.warn).toHaveBeenCalledWith({
+      expect(mockConsole.warn).toHaveBeenCalledWith("test message", {
         level: "LEVEL_WARN",
       });
     });
@@ -290,7 +299,7 @@ describe("ConsoleTransport", () => {
       });
 
       expect(levelFn).toHaveBeenCalledWith("error");
-      expect(mockConsole.error).toHaveBeenCalledWith({
+      expect(mockConsole.error).toHaveBeenCalledWith("test message", {
         level: 50,
       });
     });
@@ -309,7 +318,7 @@ describe("ConsoleTransport", () => {
         hasData: true,
       });
 
-      expect(mockConsole.warn).toHaveBeenCalledWith({
+      expect(mockConsole.warn).toHaveBeenCalledWith("test message", {
         user: "john",
         level: "warn",
       });
@@ -434,7 +443,9 @@ describe("ConsoleTransport", () => {
         messages: ["test message"],
       });
 
-      const call = (mockConsole.info as any).mock.calls[0][0];
+      expect(mockConsole.info).toHaveBeenCalledWith("test message", expect.any(String));
+
+      const call = (mockConsole.info as any).mock.calls[0][1];
       expect(typeof call).toBe("string");
       const parsed = JSON.parse(call);
       expect(parsed).toHaveProperty("timestamp");
@@ -453,7 +464,7 @@ describe("ConsoleTransport", () => {
         messages: ["test message"],
       });
 
-      expect(mockConsole.warn).toHaveBeenCalledWith('{"level":"warn"}');
+      expect(mockConsole.warn).toHaveBeenCalledWith("test message", '{"level":"warn"}');
     });
 
     it("should stringify output when stringify is true with combined fields", () => {


### PR DESCRIPTION
Closes https://github.com/loglayer/loglayer/issues/282