### PR TITLE
feat(transport-new-relic): rewrite to extend HttpTransport for v4

### DIFF
--- a/.changeset/new-relic-http-transport.md
+++ b/.changeset/new-relic-http-transport.md
@@ -1,0 +1,16 @@
+---
+"@loglayer/transport-new-relic": major
+---
+
+Rewrite New Relic transport to extend HttpTransport for Bun and Deno compatibility
+
+The NewRelicTransport now extends HttpTransport instead of LoggerlessTransport, making it compatible with Bun and Deno runtimes (uses the fetch API instead of Node.js-specific features). Benefits of the HttpTransport base include:
+- Batch sending with configurable size and timeout
+- Retry logic with exponential backoff
+- Rate limiting support
+- Compression support
+- Bun and Deno compatibility via platform-agnostic fetch API
+
+**Breaking changes:**
+- `useCompression` config option renamed to `compression` (consistent with HttpTransport)
+- `RateLimitError` is now re-exported from `@loglayer/transport-http` (same shape, same behavior)

--- a/docs/src/transports/new-relic.md
+++ b/docs/src/transports/new-relic.md
@@ -3,11 +3,11 @@ title: New Relic Transport for LogLayer
 description: Send logs to New Relic with the LogLayer logging library
 ---
 
-# New Relic Transport <Badge type="tip" text="Server" />
+# New Relic Transport <Badge type="tip" text="Server" /> <Badge type="info" text="Deno" /> <Badge type="info" text="Bun" />
 
 [![NPM Version](https://img.shields.io/npm/v/%40loglayer%2Ftransport-new-relic)](https://www.npmjs.com/package/@loglayer/transport-new-relic)
 
-The New Relic transport allows you to send logs directly to New Relic's [Log API](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/). It provides robust features including compression, retry logic, rate limiting support, and validation of New Relic's API constraints.
+The New Relic transport allows you to send logs directly to New Relic's [Log API](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/). It extends the [HTTP transport](/transports/http) to provide robust features including compression, retry logic, rate limiting support, batch sending, and validation of New Relic's API constraints. It is compatible with Node.js, Bun, and Deno.
 
 [Transport Source](https://github.com/loglayer/loglayer/tree/master/packages/transports/new-relic)
 
@@ -39,12 +39,12 @@ const log = new LogLayer({
    transport: new NewRelicTransport({
       apiKey: "YOUR_NEW_RELIC_API_KEY",
       endpoint: "https://log-api.newrelic.com/log/v1", // optional, this is the default
-      useCompression: true, // optional, defaults to true
+      compression: true, // optional, defaults to true
       maxRetries: 3, // optional, defaults to 3
       retryDelay: 1000, // optional, base delay in ms, defaults to 1000
       respectRateLimit: true, // optional, defaults to true
       onError: (err) => {
-         console.error('Failed to send logs to New Relic:', err);
+         console.error('Failed to send logs:', err);
       },
       onDebug: (entry) => {
          console.log('Log entry being sent:', entry);
@@ -70,14 +70,19 @@ log.withMetadata({ userId: "123" }).error("User not found");
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `endpoint` | `string` | `"https://log-api.newrelic.com/log/v1"` | The New Relic Log API endpoint |
-| `useCompression` | `boolean` | `true` | Whether to use gzip compression |
+| `compression` | `boolean` | `true` | Whether to use gzip compression |
 | `maxRetries` | `number` | `3` | Maximum number of retry attempts |
 | `retryDelay` | `number` | `1000` | Base delay between retries (ms) |
 | `respectRateLimit` | `boolean` | `true` | Whether to respect rate limiting |
 | `onError` | `(err: Error) => void` | - | Error handling callback |
 | `onDebug` | `(entry: Record<string, any>) => void` | - | Debug callback for inspecting log entries |
-| `enabled` | `boolean` | `true` | Whether the transport is enabled |
-| `level` | `"trace" \| "debug" \| "info" \| "warn" \| "error" \| "fatal"` | `"trace"` | Minimum log level to process. Logs below this level will be filtered out |
+| `onDebugReqRes` | `(reqRes: {...}) => void` | - | Debug callback for HTTP requests and responses |
+
+::: details Inherited HTTP Transport Options
+
+The New Relic transport extends the [HTTP transport](/transports/http) and inherits all its configuration options (batching, content types, level filtering, Next.js Edge compat, etc.). See the [HTTP transport docs](/transports/http#configuration-options) for the full list.
+
+:::
 
 ## Features
 
@@ -88,13 +93,17 @@ The transport uses gzip compression by default to reduce bandwidth usage. You ca
 ```typescript
 new NewRelicTransport({
   apiKey: "YOUR_API_KEY",
-  useCompression: false
+  compression: false
 })
 ```
 
+::: tip Next.js Edge Runtime
+Set `enableNextJsEdgeCompat: true` when using this transport in the Next.js Edge runtime. This disables compression (as `CompressionStream` is unavailable) and falls back to `Buffer.byteLength` for log size checks.
+:::
+
 ### Retry Logic
 
-The transport includes a sophisticated retry mechanism with exponential backoff and jitter:
+The transport includes a sophisticated retry mechanism with exponential backoff:
 
 ```typescript
 new NewRelicTransport({
@@ -102,11 +111,6 @@ new NewRelicTransport({
   maxRetries: 5, // Increase max retries
   retryDelay: 2000 // Increase base delay to 2 seconds
 })
-```
-
-The actual delay between retries is calculated using:
-```
-delay = baseDelay * (2 ^ attemptNumber) + random(0-200)ms
 ```
 
 ### Rate Limiting
@@ -122,7 +126,6 @@ The transport handles New Relic's rate limiting in two ways:
    ```
    - Waits for the duration specified in the `Retry-After` header
    - Rate limit retries don't count against `maxRetries`
-   - Uses 60 seconds as default wait time if no header is present
 
 2. **Ignore Rate Limits**
    ```typescript
@@ -130,14 +133,13 @@ The transport handles New Relic's rate limiting in two ways:
      apiKey: "YOUR_API_KEY",
      respectRateLimit: false,
      onError: (err) => {
-       if (err.name === "RateLimitError") {
-         // Handle rate limit error
-       }
+       // Handle rate limit errors
+       console.error("Request failed:", err.message);
      }
    })
    ```
    - Fails immediately when rate limited
-   - Calls `onError` with a `RateLimitError`
+   - Calls `onError` with the error
 
 ### Validation
 
@@ -152,7 +154,6 @@ log.withMetadata({
 ```
 
 Validation includes:
-- Maximum payload size of 1MB (before and after compression)
 - Maximum of 255 attributes per log entry
 - Maximum attribute name length of 255 characters
 - Automatic truncation of attribute values longer than 4094 characters
@@ -165,18 +166,12 @@ The transport provides detailed error information through the `onError` callback
 new NewRelicTransport({
   apiKey: "YOUR_API_KEY",
   onError: (err) => {
-    switch (err.name) {
-      case "ValidationError":
-        // Handle validation errors (payload size, attribute limits)
-        break;
-      case "RateLimitError":
-        // Handle rate limiting errors
-        const rateLimitErr = err as RateLimitError;
-        console.log(`Rate limited. Retry after: ${rateLimitErr.retryAfter}s`);
-        break;
-      default:
-        // Handle other errors (network, API errors)
-        console.error("Failed to send logs:", err.message);
+    if (err.name === "ValidationError") {
+      // Handle validation errors (attribute limits)
+      console.error("Validation error:", err.message);
+    } else {
+      // Handle other errors (network, rate limiting, API errors, etc.)
+      console.error("Failed to send logs:", err.message);
     }
   }
 })
@@ -184,7 +179,7 @@ new NewRelicTransport({
 
 ### Debug Callback
 
-The transport includes a debug callback that allows you to inspect log entries before they are sent to New Relic:
+The transport includes debug callbacks that allow you to inspect log entries and HTTP traffic:
 
 ```typescript
 new NewRelicTransport({
@@ -192,40 +187,40 @@ new NewRelicTransport({
   onDebug: (entry) => {
     // Log the entry being sent
     console.log('Sending log entry:', JSON.stringify(entry, null, 2));
+  },
+  onDebugReqRes: ({ req, res }) => {
+    // Inspect HTTP request and response
+    console.log('Request:', req.url, req.method);
+    console.log('Response:', res.status, res.statusText);
   }
 })
 ```
 
-## Best Practices
+## Migration Guide
 
-1. **Error Handling**: Always provide an `onError` callback to handle failures gracefully.
+### From v3.x to v4.x
 
-2. **Compression**: Keep compression enabled unless you have a specific reason to disable it.
+v4 rewrites the transport to extend `HttpTransport`, which enables Bun and Deno compatibility and adds batch sending support.
 
-3. **Rate Limiting**: Use the default rate limit handling unless you have a custom rate limiting strategy.
+#### Renamed configuration option
 
-4. **Retry Configuration**: Adjust `maxRetries` and `retryDelay` based on your application's needs:
-   - Increase for critical logs that must be delivered
-   - Decrease for high-volume, less critical logs
+| v3.x | v4.x |
+|------|------|
+| `useCompression` | `compression` |
 
-5. **Validation**: Be aware of the attribute limits when adding metadata to avoid validation errors.
-
-## Changelog
-
-View the changelog [here](./changelogs/new-relic-changelog.md).
-
-## TypeScript Support
-
-The transport is written in TypeScript and provides full type definitions:
-
-```typescript
-import type { NewRelicTransportConfig } from "@loglayer/transport-new-relic"
-
-const config: NewRelicTransportConfig = {
+```diff
+new NewRelicTransport({
   apiKey: "YOUR_API_KEY",
-  // TypeScript will enforce correct options
-}
-``` 
+- useCompression: true,
++ compression: true,
+})
+```
+
+#### New features inherited from HttpTransport
+
+- **Batch sending** — configurable via `enableBatchSend`, `batchSize`, `batchSendTimeout` (enabled by default)
+- **`onDebugReqRes`** — inspect HTTP request/response details
+- Full set of [HTTP transport options](/transports/http#configuration-options)
 
 ## Changelog
 

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -7,6 +7,15 @@ description: Learn about the latest features and improvements in LogLayer
 
 - [`loglayer` Changelog](/core-changelogs/loglayer-changelog)
 
+## May 11, 2026
+
+`@loglayer/transport-new-relic`:
+
+- **Major rewrite (v4):** Now extends `HttpTransport` instead of `LoggerlessTransport`, enabling **Bun** and **Deno** compatibility via the `fetch` API.
+- Adds batch sending support with configurable size and timeout.
+- **Breaking change:** `useCompression` config option renamed to `compression`.
+- See the [migration guide](/transports/new-relic#v3x-to-v4x).
+
 ## Apr 28, 2026
 
 `loglayer`:

--- a/packages/transports/new-relic/README.md
+++ b/packages/transports/new-relic/README.md
@@ -6,13 +6,13 @@
 
 The New Relic transport for the [LogLayer](https://loglayer.dev) logging library.
 
-Ships logs to New Relic using their [Log API](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/). Features include:
+Ships logs to New Relic using their [Log API](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/). Compatible with Node.js, Bun, and Deno. Features include:
 - Automatic gzip compression (configurable)
 - Retry mechanism with exponential backoff
-- Rate limiting support with configurable behavior
+- Rate limiting support
+- Batch sending with configurable size and timeout
 - Validation of New Relic's API constraints
-- Error handling callback
-- Configurable endpoints for different regions
+- Error handling and debug callbacks
 
 ## Installation
 
@@ -32,12 +32,12 @@ const log = new LogLayer({
   transport: new NewRelicTransport({
     apiKey: "YOUR_NEW_RELIC_API_KEY",
     endpoint: "https://log-api.newrelic.com/log/v1", // optional, this is the default
-    useCompression: true, // optional, defaults to true
+    compression: true, // optional, defaults to true
     maxRetries: 3, // optional, defaults to 3
     retryDelay: 1000, // optional, base delay in ms, defaults to 1000
     respectRateLimit: true, // optional, defaults to true
     onError: (err) => {
-      console.error('Failed to send logs to New Relic:', err);
+      console.error('Failed to send logs:', err);
     },
     onDebug: (entry) => {
       console.log('Log entry being sent:', entry);
@@ -64,7 +64,7 @@ interface NewRelicTransportConfig {
   apiKey: string;
   /**
    * The New Relic Log API endpoint
-   * @default https://log-api.newrelic.com/log/v1
+   * @default "https://log-api.newrelic.com/log/v1"
    */
   endpoint?: string;
   /**
@@ -73,22 +73,21 @@ interface NewRelicTransportConfig {
   onError?: (err: Error) => void;
   /**
    * Optional callback for debugging log entries
-   * Called with the validated entry before it is sent
+   * Called with the entry before it is sent
    */
   onDebug?: (entry: Record<string, any>) => void;
   /**
    * Whether to use gzip compression
    * @default true
    */
-  useCompression?: boolean;
+  compression?: boolean;
   /**
    * Number of retry attempts before giving up
    * @default 3
    */
   maxRetries?: number;
   /**
-   * Base delay between retries in milliseconds. 
-   * The actual delay will use exponential backoff with jitter.
+   * Base delay between retries in milliseconds
    * @default 1000
    */
   retryDelay?: number;
@@ -102,4 +101,4 @@ interface NewRelicTransportConfig {
 
 ## Documentation
 
-For more details, visit [https://loglayer.dev/transports/new-relic](https://loglayer.dev/transports/new-relic) 
+For more details, visit [https://loglayer.dev/transports/new-relic](https://loglayer.dev/transports/new-relic)

--- a/packages/transports/new-relic/package.json
+++ b/packages/transports/new-relic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loglayer/transport-new-relic",
   "description": "New Relic transport for the LogLayer logging library.",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -43,10 +43,11 @@
     "livetest": "tsx src/__tests__/livetest.ts"
   },
   "dependencies": {
-    "@loglayer/transport": "workspace:*"
+    "@loglayer/transport-http": "workspace:*"
   },
   "devDependencies": {
     "@internal/tsconfig": "workspace:*",
+    "@loglayer/transport": "workspace:*",
     "@types/node": "25.2.3",
     "dotenv": "17.3.1",
     "loglayer": "workspace:*",
@@ -58,7 +59,9 @@
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "bun": ">=1.0.0",
+    "deno": ">=1.40"
   },
   "files": [
     "dist"

--- a/packages/transports/new-relic/src/NewRelicTransport.ts
+++ b/packages/transports/new-relic/src/NewRelicTransport.ts
@@ -1,17 +1,16 @@
-import type { LoggerlessTransportConfig, LogLayerTransportParams } from "@loglayer/transport";
-import { LoggerlessTransport } from "@loglayer/transport";
+import type { HttpTransportConfig } from "@loglayer/transport-http";
+import { HttpTransport } from "@loglayer/transport-http";
 
 // Constants defining New Relic's API limits
-const MAX_PAYLOAD_SIZE = 1_000_000; // 1MB in bytes
 const MAX_ATTRIBUTES = 255;
 const MAX_ATTRIBUTE_NAME_LENGTH = 255;
 const MAX_ATTRIBUTE_VALUE_LENGTH = 4094;
 
 /**
  * Error thrown when log entry validation fails.
- * This includes payload size, attribute count, and attribute name length validations.
+ * This includes attribute count, attribute name length, and other New Relic API validations.
  */
-class ValidationError extends Error {
+export class ValidationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ValidationError";
@@ -19,381 +18,125 @@ class ValidationError extends Error {
 }
 
 /**
- * Error thrown when New Relic's API rate limit is exceeded.
- * Contains the retry-after duration specified by the API.
- */
-class RateLimitError extends Error {
-  constructor(
-    message: string,
-    public retryAfter: number,
-  ) {
-    super(message);
-    this.name = "RateLimitError";
-  }
-}
-
-/**
  * Configuration options for the New Relic transport.
+ * Extends HttpTransportConfig with New Relic-specific options.
  */
-export interface NewRelicTransportConfig extends LoggerlessTransportConfig {
+export interface NewRelicTransportConfig extends Omit<HttpTransportConfig, "url" | "headers" | "payloadTemplate"> {
   /**
    * The New Relic API key
    */
   apiKey: string;
   /**
    * The New Relic Log API endpoint
-   * @default https://log-api.newrelic.com/log/v1
+   * @default "https://log-api.newrelic.com/log/v1"
    */
   endpoint?: string;
   /**
-   * Optional callback for error handling
+   * Custom payload template function (optional, defaults to New Relic format).
+   * Receives log level, message, and optional data (metadata).
    */
-  onError?: (err: Error) => void;
-  /**
-   * Optional callback for debugging log entries before they are sent
-   */
-  onDebug?: (entry: Record<string, any>) => void;
-  /**
-   * Whether to use gzip compression
-   * @default true
-   */
-  useCompression?: boolean;
-  /**
-   * Number of retry attempts before giving up
-   * @default 3
-   */
-  maxRetries?: number;
-  /**
-   * Base delay between retries in milliseconds
-   * @default 1000
-   */
-  retryDelay?: number;
-  /**
-   * Whether to respect rate limiting by waiting when a 429 response is received
-   * @default true
-   */
-  respectRateLimit?: boolean;
+  payloadTemplate?: (params: { logLevel: string; message: string; data?: Record<string, any> }) => string;
 }
 
 /**
- * Validates a log entry against New Relic's constraints.
+ * Validates attributes against New Relic's constraints.
  * - Checks number of attributes (max 255)
  * - Validates attribute name length (max 255 characters)
  * - Truncates attribute values longer than 4094 characters
  *
- * @param logEntry - The log entry to validate
- * @returns The validated (and potentially modified) log entry
+ * @param attributes - The attributes to validate
+ * @returns The validated (and potentially modified) attributes
  * @throws {ValidationError} If validation fails
  */
-function validateLogEntry(logEntry: Record<string, any>) {
-  if (logEntry.attributes) {
-    // Check number of attributes
-    const attributeCount = Object.keys(logEntry.attributes).length;
-    if (attributeCount > MAX_ATTRIBUTES) {
+function validateAttributes(attributes: Record<string, any>): Record<string, any> {
+  const validated: Record<string, any> = {};
+
+  // Check number of attributes
+  const attributeCount = Object.keys(attributes).length;
+  if (attributeCount > MAX_ATTRIBUTES) {
+    throw new ValidationError(
+      `Log entry exceeds maximum number of attributes (${MAX_ATTRIBUTES}). Found: ${attributeCount}`,
+    );
+  }
+
+  // Check attribute names and values
+  for (const [key, value] of Object.entries(attributes)) {
+    // Check attribute name length
+    if (key.length > MAX_ATTRIBUTE_NAME_LENGTH) {
       throw new ValidationError(
-        `Log entry exceeds maximum number of attributes (${MAX_ATTRIBUTES}). Found: ${attributeCount}`,
+        `Attribute name exceeds maximum length (${MAX_ATTRIBUTE_NAME_LENGTH}). Found: ${key.length}`,
       );
     }
 
-    // Check attribute names and values
-    for (const [key, value] of Object.entries(logEntry.attributes)) {
-      // Check attribute name length
-      if (key.length > MAX_ATTRIBUTE_NAME_LENGTH) {
-        throw new ValidationError(
-          `Attribute name '${key}' exceeds maximum length (${MAX_ATTRIBUTE_NAME_LENGTH}). Length: ${key.length}`,
-        );
-      }
-
-      // Check string value length
-      if (typeof value === "string" && value.length > MAX_ATTRIBUTE_VALUE_LENGTH) {
-        // Truncate the string value to the maximum length
-        logEntry.attributes[key] = value.slice(0, MAX_ATTRIBUTE_VALUE_LENGTH);
-      }
+    // Truncate string values that are too long
+    if (typeof value === "string" && value.length > MAX_ATTRIBUTE_VALUE_LENGTH) {
+      validated[key] = value.slice(0, MAX_ATTRIBUTE_VALUE_LENGTH);
+    } else {
+      validated[key] = value;
     }
   }
 
-  return logEntry;
+  return validated;
+}
+
+/**
+ * Default payload template that formats log data for New Relic's Log API.
+ * Each entry includes timestamp, level, the log message, and optional attributes.
+ */
+function defaultNewRelicPayload(params: { logLevel: string; message: string; data?: Record<string, any> }): string {
+  const logEntry: Record<string, any> = {
+    timestamp: Date.now(),
+    level: params.logLevel,
+    log: params.message,
+  };
+
+  if (params.data) {
+    logEntry.attributes = validateAttributes(params.data);
+  }
+
+  return JSON.stringify(logEntry);
 }
 
 /**
  * NewRelicTransport is responsible for sending logs to New Relic's Log API.
- * It handles validation, compression, retries, and rate limiting according to New Relic's specifications.
+ * It extends HttpTransport with New Relic-specific configuration, validation,
+ * and formatting.
  *
  * Features:
- * - Validates payload size (max 1MB)
- * - Validates number of attributes (max 255)
+ * - Validates attribute count (max 255)
  * - Validates attribute name length (max 255 characters)
  * - Truncates attribute values longer than 4094 characters
- * - Supports gzip compression
- * - Handles rate limiting with configurable behavior
- * - Implements retry logic with exponential backoff
+ * - Gzip compression by default (via HttpTransport)
+ * - Retry logic with exponential backoff (via HttpTransport)
+ * - Rate limiting support (via HttpTransport)
+ * - Batch sending support (via HttpTransport)
+ * - Error and debug callbacks
  */
-export class NewRelicTransport extends LoggerlessTransport {
-  private apiKey: string;
-  private endpoint: string;
-  private onError?: (err: Error) => void;
-  private onDebug?: (entry: Record<string, any>) => void;
-  private useCompression: boolean;
-  private maxRetries: number;
-  private retryDelay: number;
-  private respectRateLimit: boolean;
-
+export class NewRelicTransport extends HttpTransport {
   /**
    * Creates a new instance of NewRelicTransport.
    *
    * @param config - Configuration options for the transport
-   * @param config.apiKey - New Relic API key for authentication
-   * @param config.endpoint - Optional custom endpoint URL (defaults to New Relic's Log API endpoint)
-   * @param config.onError - Optional error callback for handling errors
-   * @param config.onDebug - Optional callback for debugging log entries before they are sent
-   * @param config.useCompression - Whether to use gzip compression (defaults to true)
-   * @param config.maxRetries - Maximum number of retry attempts (defaults to 3)
-   * @param config.retryDelay - Base delay between retries in milliseconds (defaults to 1000)
-   * @param config.respectRateLimit - Whether to honor rate limiting headers (defaults to true)
    */
   constructor(config: NewRelicTransportConfig) {
-    super(config);
+    const { apiKey, endpoint, payloadTemplate, ...httpConfig } = config;
 
-    this.apiKey = config.apiKey;
-    this.endpoint = config.endpoint ?? "https://log-api.newrelic.com/log/v1";
-    this.onError = config.onError;
-    this.onDebug = config.onDebug;
-    this.useCompression = config.useCompression ?? true;
-    this.maxRetries = config.maxRetries ?? 3;
-    this.retryDelay = config.retryDelay ?? 1000;
-    this.respectRateLimit = config.respectRateLimit ?? true;
+    super({
+      ...httpConfig,
+      url: endpoint ?? "https://log-api.newrelic.com/log/v1",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Api-Key": apiKey,
+      },
+      payloadTemplate: payloadTemplate ?? defaultNewRelicPayload,
+      // Defaults (only apply if not provided)
+      compression: httpConfig.compression ?? true,
+      maxRetries: httpConfig.maxRetries ?? 3,
+      retryDelay: httpConfig.retryDelay ?? 1000,
+      respectRateLimit: httpConfig.respectRateLimit ?? true,
+      maxLogSize: httpConfig.maxLogSize ?? 1_048_576,
+      maxPayloadSize: httpConfig.maxPayloadSize ?? 1_048_576,
+    } as HttpTransportConfig);
   }
-
-  /**
-   * Processes and ships log entries to New Relic.
-   *
-   * This method:
-   * 1. Validates the message size
-   * 2. Creates and validates the log entry
-   * 3. Validates the final payload size
-   * 4. Asynchronously sends the log entry to New Relic
-   *
-   * The actual sending is done asynchronously in a fire-and-forget manner to maintain
-   * compatibility with the base transport class while still providing retry and error handling.
-   *
-   * @param params - Log parameters including level, messages, and metadata
-   * @param params.logLevel - The severity level of the log
-   * @param params.messages - Array of message strings to be joined
-   * @param params.data - Optional metadata to include with the log
-   * @param params.hasData - Whether metadata is present
-   * @returns The original messages array
-   * @throws {ValidationError} If the payload exceeds size limits or validation fails
-   */
-  shipToLogger({ logLevel, messages, data, hasData }: LogLayerTransportParams): any[] {
-    try {
-      // Check message size first
-      const message = messages.join(" ");
-      const messageBytes = new TextEncoder().encode(message).length;
-      if (messageBytes > MAX_PAYLOAD_SIZE) {
-        throw new ValidationError(
-          `Payload size exceeds maximum of ${MAX_PAYLOAD_SIZE} bytes. Size: ${messageBytes} bytes`,
-        );
-      }
-
-      const logEntry: Record<string, any> = {
-        timestamp: Date.now(),
-        level: logLevel,
-        log: message,
-      };
-
-      if (data && hasData) {
-        Object.assign(logEntry, {
-          attributes: data,
-        });
-      }
-
-      const validatedEntry = validateLogEntry(logEntry);
-
-      // Call onDebug callback if defined
-      if (this.onDebug) {
-        this.onDebug(validatedEntry);
-      }
-
-      // Check final payload size
-      const payload = JSON.stringify([validatedEntry]);
-      const payloadBytes = new TextEncoder().encode(payload).length;
-      if (payloadBytes > MAX_PAYLOAD_SIZE) {
-        throw new ValidationError(
-          `Payload size exceeds maximum of ${MAX_PAYLOAD_SIZE} bytes. Size: ${payloadBytes} bytes`,
-        );
-      }
-
-      // Fire and forget the async processing
-      (async () => {
-        try {
-          await sendWithRetry(
-            this.endpoint,
-            this.apiKey,
-            payload,
-            this.useCompression,
-            this.maxRetries,
-            this.retryDelay,
-            this.respectRateLimit,
-          );
-        } catch (error) {
-          if (this.onError) {
-            this.onError(error instanceof Error ? error : new Error(String(error)));
-          }
-          // Re-throw validation errors to prevent further processing
-          if (error instanceof ValidationError) {
-            throw error;
-          }
-        }
-      })();
-    } catch (error) {
-      if (this.onError) {
-        this.onError(error instanceof Error ? error : new Error(String(error)));
-      }
-    }
-
-    return messages;
-  }
-}
-
-/**
- * Compresses data using gzip compression.
- *
- * @param data - The string data to compress
- * @returns A promise that resolves to the compressed data as a Uint8Array
- */
-async function compressData(data: string): Promise<Uint8Array> {
-  const stream = new CompressionStream("gzip");
-  const writer = stream.writable.getWriter();
-  const encoder = new TextEncoder();
-  const chunks: Uint8Array[] = [];
-
-  await writer.write(encoder.encode(data));
-  await writer.close();
-
-  const reader = stream.readable.getReader();
-
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-  }
-
-  // Combine all chunks into a single Uint8Array
-  const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
-  }
-
-  return result;
-}
-
-/**
- * Sends a log entry to New Relic with retry logic.
- * Handles rate limiting, compression, and error cases.
- *
- * @param endpoint - The New Relic API endpoint
- * @param apiKey - The New Relic API key
- * @param payload - The JSON payload to send
- * @param useCompression - Whether to use gzip compression
- * @param maxRetries - Maximum number of retry attempts
- * @param retryDelay - Base delay between retries in milliseconds
- * @param respectRateLimit - Whether to honor rate limiting headers
- * @returns A promise that resolves to the API response
- * @throws {ValidationError} If payload validation fails
- * @throws {RateLimitError} If rate limited and not respecting rate limits
- * @throws {Error} If the request fails after all retries
- */
-async function sendWithRetry(
-  endpoint: string,
-  apiKey: string,
-  payload: string,
-  useCompression: boolean,
-  maxRetries: number,
-  retryDelay: number,
-  respectRateLimit = true,
-): Promise<Response> {
-  // Check payload size before compression
-  const payloadBytes = new TextEncoder().encode(payload).length;
-  if (payloadBytes > MAX_PAYLOAD_SIZE) {
-    throw new ValidationError(`Payload size exceeds maximum of ${MAX_PAYLOAD_SIZE} bytes. Size: ${payloadBytes} bytes`);
-  }
-
-  let lastError: Error;
-  let compressedPayload: Uint8Array | undefined;
-
-  if (useCompression) {
-    compressedPayload = await compressData(payload);
-    // Check compressed payload size
-    if (compressedPayload.length > MAX_PAYLOAD_SIZE) {
-      throw new ValidationError(
-        `Compressed payload size exceeds maximum of ${MAX_PAYLOAD_SIZE} bytes. Size: ${compressedPayload.length} bytes`,
-      );
-    }
-  }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "Api-Key": apiKey,
-  };
-
-  if (useCompression) {
-    headers["Content-Encoding"] = "gzip";
-  }
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const response = await fetch(endpoint, {
-        method: "POST",
-        headers,
-        body: useCompression ? compressedPayload : payload,
-      });
-
-      if (response.status === 429) {
-        const retryAfter = Number.parseInt(response.headers.get("Retry-After") || "60", 10);
-        if (respectRateLimit) {
-          // Wait for the specified time before retrying
-          await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
-          // Don't count rate limit retries against maxRetries
-          attempt--;
-          continue;
-        }
-
-        throw new RateLimitError(`Rate limit exceeded. Retry after ${retryAfter} seconds`, retryAfter);
-      }
-
-      if (!response.ok) {
-        throw new Error(`Failed to send logs to New Relic: ${response.statusText}`);
-      }
-
-      return response;
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-
-      // Don't retry validation errors
-      if (error instanceof ValidationError) {
-        throw error;
-      }
-
-      // If we're not respecting rate limits, don't retry rate limit errors
-      if (!respectRateLimit && error instanceof RateLimitError) {
-        throw error;
-      }
-
-      if (attempt === maxRetries) {
-        throw new Error(`Failed to send logs after ${maxRetries} retries: ${lastError.message}`);
-      }
-
-      // For non-rate-limit errors, use exponential backoff with jitter
-      if (!(error instanceof RateLimitError)) {
-        const jitter = Math.random() * 200;
-        const delay = retryDelay * 2 ** attempt + jitter;
-        await new Promise((resolve) => setTimeout(resolve, delay));
-      }
-    }
-  }
-
-  throw lastError!;
 }

--- a/packages/transports/new-relic/src/__tests__/NewRelicTransport.test.ts
+++ b/packages/transports/new-relic/src/__tests__/NewRelicTransport.test.ts
@@ -1,532 +1,394 @@
-import { LogLayer } from "loglayer";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NewRelicTransport } from "../NewRelicTransport.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NewRelicTransport, ValidationError } from "../NewRelicTransport.js";
+
+// Mock the HttpTransport module
+vi.mock("@loglayer/transport-http", () => ({
+  HttpTransport: vi.fn(),
+  RateLimitError: class RateLimitError extends Error {
+    constructor(
+      message: string,
+      public retryAfter: number,
+    ) {
+      super(message);
+      this.name = "RateLimitError";
+    }
+  },
+}));
 
 describe("NewRelicTransport", () => {
-  let mockFetch: ReturnType<typeof vi.fn>;
-  let originalFetch: typeof fetch;
+  let HttpTransportMock: any;
 
-  beforeEach(() => {
-    vi.useFakeTimers();
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { HttpTransport } = await import("@loglayer/transport-http");
+    HttpTransportMock = vi.mocked(HttpTransport);
+  });
 
-    // Store original fetch
-    originalFetch = global.fetch;
+  it("should export ValidationError", () => {
+    expect(ValidationError).toBeDefined();
+    const error = new ValidationError("test error");
+    expect(error.name).toBe("ValidationError");
+    expect(error.message).toBe("test error");
+  });
 
-    // Mock fetch function
-    mockFetch = vi.fn(() =>
-      Promise.resolve(
-        new Response(null, {
-          status: 200,
-          statusText: "OK",
+  it("should re-export RateLimitError from http transport", async () => {
+    const index = await import("../index.js");
+    expect(index.RateLimitError).toBeDefined();
+    const error = new index.RateLimitError("rate limited", 30);
+    expect(error.name).toBe("RateLimitError");
+    expect(error.message).toBe("rate limited");
+    expect(error.retryAfter).toBe(30);
+  });
+
+  describe("constructor", () => {
+    it("should create transport with required configuration", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      expect(HttpTransportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://log-api.newrelic.com/log/v1",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Api-Key": "test-api-key",
+          },
+          payloadTemplate: expect.any(Function),
+          compression: true,
+          maxRetries: 3,
+          retryDelay: 1000,
+          respectRateLimit: true,
+          maxLogSize: 1_048_576,
+          maxPayloadSize: 1_048_576,
         }),
-      ),
-    );
-    global.fetch = mockFetch as typeof fetch;
-
-    // Mock CompressionStream
-    const mockWriter = {
-      write: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-
-    const mockReader = {
-      read: vi
-        .fn()
-        .mockResolvedValueOnce({ value: new Uint8Array([1, 2, 3]), done: false })
-        .mockResolvedValueOnce({ done: true }),
-    };
-
-    const mockStream = {
-      writable: { getWriter: () => mockWriter },
-      readable: { getReader: () => mockReader },
-    };
-
-    global.CompressionStream = vi.fn(function () {
-      return mockStream;
-    }) as unknown as typeof CompressionStream;
-    global.TextEncoder = vi.fn(function () {
-      return {
-        encode: (str: string) => new Uint8Array(str.length),
-      };
-    }) as unknown as typeof TextEncoder;
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    // Restore original fetch
-    global.fetch = originalFetch;
-  });
-
-  it("should send logs to New Relic", async () => {
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-      }),
+      );
     });
 
-    const sendPromise = log.info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://log-api.newrelic.com/log/v1",
-      expect.objectContaining({
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Api-Key": "test-api-key",
-        },
-        body: expect.stringContaining("test message"),
-      }),
-    );
-  });
-
-  it("should handle payload size limit", async () => {
-    const onError = vi.fn();
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-        onError,
-      }),
-    });
-
-    // Create a large string that exceeds 1MB
-    const largeString = "x".repeat(1_000_001);
-    log.info(largeString);
-
-    // Wait for the next tick to allow error handling to complete
-    await vi.runAllTimersAsync();
-    await new Promise((resolve) => process.nextTick(resolve));
-
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "ValidationError",
-        message: expect.stringContaining("Payload size exceeds maximum"),
-      }),
-    );
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("should handle maximum number of attributes", async () => {
-    const onError = vi.fn();
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        onError,
-      }),
-    });
-
-    // Create an object with more than 255 attributes
-    const metadata: Record<string, string> = {};
-    for (let i = 0; i < 256; i++) {
-      metadata[`key${i}`] = `value${i}`;
-    }
-
-    const sendPromise = log.withMetadata(metadata).info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "ValidationError",
-        message: expect.stringContaining("exceeds maximum number of attributes"),
-      }),
-    );
-  });
-
-  it("should handle attribute name length limit", async () => {
-    const onError = vi.fn();
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        onError,
-      }),
-    });
-
-    // Create an attribute name longer than 255 characters
-    const longKey = "x".repeat(256);
-    const sendPromise = log.withMetadata({ [longKey]: "value" }).info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "ValidationError",
-        message: expect.stringContaining("exceeds maximum length"),
-      }),
-    );
-  });
-
-  it("should truncate attribute values longer than 4094 characters", async () => {
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-      }),
-    });
-
-    // Create a string longer than 4094 characters
-    const longValue = "x".repeat(5000);
-    const sendPromise = log.withMetadata({ test: longValue }).info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    const expectedTruncated = `"attributes":{"test":"${("x").repeat(4094)}"}`;
-    const notExpectedLonger = `"attributes":{"test":"${("x").repeat(4095)}"}`;
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        body: expect.stringContaining(expectedTruncated),
-      }),
-    );
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.not.objectContaining({
-        body: expect.stringContaining(notExpectedLonger),
-      }),
-    );
-  });
-
-  it("should use gzip compression by default", async () => {
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-      }),
-    });
-
-    const sendPromise = log.info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "Content-Encoding": "gzip",
-        }),
-        body: expect.any(Uint8Array),
-      }),
-    );
-    expect(global.CompressionStream).toHaveBeenCalledWith("gzip");
-  });
-
-  it("should use custom endpoint", async () => {
-    const customEndpoint = "https://custom.newrelic.com/logs";
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
+    it("should create transport with custom endpoint", () => {
+      const customEndpoint = "https://custom.newrelic.com/logs";
+      new NewRelicTransport({
         apiKey: "test-api-key",
         endpoint: customEndpoint,
-        useCompression: false,
-      }),
-    });
+      });
 
-    const sendPromise = log.info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledWith(customEndpoint, expect.any(Object));
-  });
-
-  it("should retry on failure", async () => {
-    mockFetch
-      .mockImplementationOnce(() => Promise.reject(new Error("Network error")))
-      .mockImplementationOnce(() => Promise.reject(new Error("Network error")))
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 200,
-            statusText: "OK",
-          }),
-        ),
-      );
-
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-        retryDelay: 10,
-      }),
-    });
-
-    const sendPromise = log.info("test message");
-
-    // Run timers for each retry attempt
-    for (let i = 0; i < 3; i++) {
-      await vi.runAllTimersAsync();
-    }
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-  });
-
-  it("should not retry on validation errors", async () => {
-    const onError = vi.fn();
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-        onError,
-      }),
-    });
-
-    // Create a payload that exceeds size limit
-    const largeString = "x".repeat(1_000_001);
-    log.info(largeString);
-
-    // Wait for the next tick to allow error handling to complete
-    await vi.runAllTimersAsync();
-    await new Promise((resolve) => process.nextTick(resolve));
-
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "ValidationError",
-      }),
-    );
-  });
-
-  it("should call onError after max retries", async () => {
-    const error = new Error("Network error");
-    mockFetch.mockImplementation(() => Promise.reject(error));
-
-    const onError = vi.fn();
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-        retryDelay: 10,
-        maxRetries: 2,
-        onError,
-      }),
-    });
-
-    const sendPromise = log.info("test message");
-
-    // Run timers for each retry attempt
-    for (let i = 0; i <= 2; i++) {
-      await vi.runAllTimersAsync();
-    }
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-    expect(onError).toHaveBeenCalledWith(expect.any(Error));
-    expect(onError.mock.calls[0][0].message).toContain("Failed to send logs after 2 retries");
-  });
-
-  it("should include metadata in log entry", async () => {
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-      }),
-    });
-
-    const sendPromise = log.withMetadata({ test: "data" }).info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        body: expect.stringContaining('"attributes":{"test":"data"}'),
-      }),
-    );
-  });
-
-  it("should handle rate limiting with Retry-After header", async () => {
-    const retryAfter = 30; // 30 seconds
-    mockFetch
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 429,
-            statusText: "Too Many Requests",
-            headers: new Headers({
-              "Retry-After": retryAfter.toString(),
-            }),
-          }),
-        ),
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 200,
-            statusText: "OK",
-          }),
-        ),
-      );
-
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
-        apiKey: "test-api-key",
-        useCompression: false,
-        retryDelay: 10,
-      }),
-    });
-
-    const sendPromise = log.info("test message");
-
-    // Fast-forward time by the retry-after duration
-    await vi.advanceTimersByTimeAsync(retryAfter * 1000);
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it("should not retry on rate limit when respectRateLimit is false", async () => {
-    const retryAfter = 30; // 30 seconds
-    mockFetch.mockImplementationOnce(() =>
-      Promise.resolve(
-        new Response(null, {
-          status: 429,
-          statusText: "Too Many Requests",
-          headers: new Headers({
-            "Retry-After": retryAfter.toString(),
-          }),
+      expect(HttpTransportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: customEndpoint,
         }),
-      ),
-    );
+      );
+    });
 
-    const onError = vi.fn();
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
+    it("should create transport with custom configuration", () => {
+      new NewRelicTransport({
         apiKey: "test-api-key",
-        useCompression: false,
+        endpoint: "https://custom.newrelic.com/logs",
+        compression: false,
+        maxRetries: 5,
+        retryDelay: 2000,
         respectRateLimit: false,
+        enableBatchSend: false,
+        batchSize: 50,
+        batchSendTimeout: 3000,
+      });
+
+      expect(HttpTransportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://custom.newrelic.com/logs",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Api-Key": "test-api-key",
+          },
+          compression: false,
+          maxRetries: 5,
+          retryDelay: 2000,
+          respectRateLimit: false,
+          enableBatchSend: false,
+          batchSize: 50,
+          batchSendTimeout: 3000,
+        }),
+      );
+    });
+
+    it("should create transport with error and debug callbacks", () => {
+      const onError = vi.fn();
+      const onDebug = vi.fn();
+      const onDebugReqRes = vi.fn();
+
+      new NewRelicTransport({
+        apiKey: "test-api-key",
         onError,
-      }),
+        onDebug,
+        onDebugReqRes,
+      });
+
+      expect(HttpTransportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onError,
+          onDebug,
+          onDebugReqRes,
+        }),
+      );
     });
 
-    const sendPromise = log.info("test message");
-    await vi.runAllTimersAsync();
-    await sendPromise;
+    it("should use default payload template with correct New Relic format", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "RateLimitError",
-        message: expect.stringContaining(`Retry after ${retryAfter} seconds`),
-      }),
-    );
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const result = payloadTemplate({
+        logLevel: "info",
+        message: "test message",
+        data: { userId: "123", action: "login" },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.level).toBe("info");
+      expect(parsed.log).toBe("test message");
+      expect(parsed.timestamp).toBeDefined();
+      expect(typeof parsed.timestamp).toBe("number");
+      expect(parsed.attributes).toEqual({ userId: "123", action: "login" });
+    });
+
+    it("should handle logs without data in payload template", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const result = payloadTemplate({
+        logLevel: "debug",
+        message: "debug message",
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.level).toBe("debug");
+      expect(parsed.log).toBe("debug message");
+      expect(parsed.attributes).toBeUndefined();
+    });
+
+    it("should handle empty data in payload template", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const result = payloadTemplate({
+        logLevel: "warn",
+        message: "warning message",
+        data: {},
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.level).toBe("warn");
+      expect(parsed.log).toBe("warning message");
+      expect(parsed.attributes).toEqual({});
+    });
+
+    it("should pass through enabled and level configuration", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+        enabled: false,
+        level: "warn",
+      });
+
+      expect(HttpTransportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: false,
+          level: "warn",
+        }),
+      );
+    });
   });
 
-  it("should not count rate limit retries against maxRetries", async () => {
-    const retryAfter = 5; // 5 seconds
-    mockFetch
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 429,
-            statusText: "Too Many Requests",
-            headers: new Headers({
-              "Retry-After": retryAfter.toString(),
-            }),
-          }),
-        ),
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 429,
-            statusText: "Too Many Requests",
-            headers: new Headers({
-              "Retry-After": retryAfter.toString(),
-            }),
-          }),
-        ),
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 500,
-            statusText: "Internal Server Error",
-          }),
-        ),
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 200,
-            statusText: "OK",
-          }),
-        ),
-      );
-
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
+  describe("attribute validation", () => {
+    it("should throw ValidationError for too many attributes", () => {
+      new NewRelicTransport({
         apiKey: "test-api-key",
-        useCompression: false,
-        maxRetries: 1,
-        retryDelay: 10,
-      }),
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const metadata: Record<string, string> = {};
+      for (let i = 0; i < 256; i++) {
+        metadata[`key${i}`] = `value${i}`;
+      }
+
+      expect(() =>
+        payloadTemplate({
+          logLevel: "info",
+          message: "test",
+          data: metadata,
+        }),
+      ).toThrow(ValidationError);
     });
 
-    const sendPromise = log.info("test message");
+    it("should throw ValidationError for attribute name too long", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
 
-    // Fast-forward time for each retry
-    await vi.advanceTimersByTimeAsync(retryAfter * 1000);
-    await vi.advanceTimersByTimeAsync(retryAfter * 1000);
-    await vi.advanceTimersByTimeAsync(10); // Regular retry delay
-    await vi.runAllTimersAsync();
-    await sendPromise;
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
 
-    expect(mockFetch).toHaveBeenCalledTimes(4);
+      const longKey = "x".repeat(256);
+
+      expect(() =>
+        payloadTemplate({
+          logLevel: "info",
+          message: "test",
+          data: { [longKey]: "value" },
+        }),
+      ).toThrow(ValidationError);
+    });
+
+    it("should truncate attribute values longer than 4094 characters", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const longValue = "x".repeat(5000);
+
+      const result = payloadTemplate({
+        logLevel: "info",
+        message: "test message",
+        data: { test: longValue },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.attributes.test).toBe("x".repeat(4094));
+    });
+
+    it("should handle complex metadata correctly", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const result = payloadTemplate({
+        logLevel: "error",
+        message: "error message",
+        data: {
+          userId: "123",
+          requestId: "req-456",
+          error: {
+            name: "ValidationError",
+            message: "Invalid input",
+          },
+          tags: ["api", "validation"],
+          duration: 150,
+        },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.level).toBe("error");
+      expect(parsed.log).toBe("error message");
+      expect(parsed.attributes.userId).toBe("123");
+      expect(parsed.attributes.requestId).toBe("req-456");
+      expect(parsed.attributes.error).toEqual({
+        name: "ValidationError",
+        message: "Invalid input",
+      });
+      expect(parsed.attributes.tags).toEqual(["api", "validation"]);
+      expect(parsed.attributes.duration).toBe(150);
+    });
+
+    it("should handle special characters in message and metadata", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const result = payloadTemplate({
+        logLevel: "info",
+        message: "Message with special chars: éñ中文🚀",
+        data: {
+          "field-with-dash": "value",
+          field_with_underscore: "value",
+          "field.with.dots": "value",
+        },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.log).toBe("Message with special chars: éñ中文🚀");
+      expect(parsed.level).toBe("info");
+      expect(parsed.attributes["field-with-dash"]).toBe("value");
+      expect(parsed.attributes.field_with_underscore).toBe("value");
+      expect(parsed.attributes["field.with.dots"]).toBe("value");
+    });
+
+    it("should allow exactly 255 attributes (the max)", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const metadata: Record<string, string> = {};
+      for (let i = 0; i < 255; i++) {
+        metadata[`key${i}`] = `value${i}`;
+      }
+
+      expect(() =>
+        payloadTemplate({
+          logLevel: "info",
+          message: "test",
+          data: metadata,
+        }),
+      ).not.toThrow();
+    });
+
+    it("should allow attribute names of exactly 255 characters (the max)", () => {
+      new NewRelicTransport({
+        apiKey: "test-api-key",
+      });
+
+      const callArgs = HttpTransportMock.mock.calls[0][0];
+      const payloadTemplate = callArgs.payloadTemplate;
+
+      const exactLengthKey = "x".repeat(255);
+
+      expect(() =>
+        payloadTemplate({
+          logLevel: "info",
+          message: "test",
+          data: { [exactLengthKey]: "value" },
+        }),
+      ).not.toThrow();
+    });
   });
 
-  it("should use default retry-after of 60 seconds when header is missing", async () => {
-    mockFetch
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 429,
-            statusText: "Too Many Requests",
-          }),
-        ),
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(null, {
-            status: 200,
-            statusText: "OK",
-          }),
-        ),
-      );
+  describe("custom payloadTemplate", () => {
+    it("should accept a custom payloadTemplate", () => {
+      const customTemplate = vi.fn(() => JSON.stringify({ custom: "format" }));
 
-    const log = new LogLayer({
-      transport: new NewRelicTransport({
-        id: "new-relic",
+      new NewRelicTransport({
         apiKey: "test-api-key",
-        useCompression: false,
-        retryDelay: 10,
-      }),
+        payloadTemplate: customTemplate,
+      });
+
+      expect(HttpTransportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payloadTemplate: customTemplate,
+        }),
+      );
     });
-
-    const sendPromise = log.info("test message");
-
-    // Fast-forward time by the default retry-after duration
-    await vi.advanceTimersByTimeAsync(60 * 1000);
-    await vi.runAllTimersAsync();
-    await sendPromise;
-
-    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/transports/new-relic/src/__tests__/livetest.ts
+++ b/packages/transports/new-relic/src/__tests__/livetest.ts
@@ -15,7 +15,8 @@ const log = new LogLayer({
   transport: new NewRelicTransport({
     apiKey: process.env.NEW_RELIC_API_KEY,
     endpoint: "https://log-api.newrelic.com/log/v1", // optional, this is the default
-    useCompression: true, // optional, defaults to true
+    compression: true, // optional, defaults to true
+    enableBatchSend: false, // disable batching so each log is sent immediately
     maxRetries: 3, // optional, defaults to 3
     retryDelay: 1000, // optional, base delay in ms, defaults to 1000
     respectRateLimit: true, // optional, defaults to true

--- a/packages/transports/new-relic/src/index.ts
+++ b/packages/transports/new-relic/src/index.ts
@@ -1,1 +1,3 @@
-export * from "./NewRelicTransport.js";
+export { HttpTransportError, LogSizeError, RateLimitError } from "@loglayer/transport-http";
+export type { NewRelicTransportConfig } from "./NewRelicTransport.js";
+export { NewRelicTransport, ValidationError } from "./NewRelicTransport.js";

--- a/packages/transports/new-relic/turbo.json
+++ b/packages/transports/new-relic/turbo.json
@@ -30,6 +30,7 @@
       "dependsOn": [
         "@internal/tsconfig#build",
         "@loglayer/transport#build",
+        "@loglayer/transport-http#build",
         "loglayer#build"
       ],
       "inputs": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1411,13 +1411,16 @@ importers:
 
   packages/transports/new-relic:
     dependencies:
-      '@loglayer/transport':
+      '@loglayer/transport-http':
         specifier: workspace:*
-        version: link:../../core/transport
+        version: link:../http
     devDependencies:
       '@internal/tsconfig':
         specifier: workspace:*
         version: link:../../core/tsconfig
+      '@loglayer/transport':
+        specifier: workspace:*
+        version: link:../../core/transport
       '@types/node':
         specifier: 25.2.3
         version: 25.2.3


### PR DESCRIPTION
## Summary

Rewrites `NewRelicTransport` to extend `HttpTransport` instead of `LoggerlessTransport`, enabling **Bun**, **Deno**, and **Next.js Edge** runtime support. Inherits batch sending, gzip compression, retry logic, and rate limiting from HttpTransport.

## Changes

- `NewRelicTransport` now extends `HttpTransport` with spread-based config pass-through
- Keeps New Relic-specific validation (max 255 attributes, 255-char names, 4094-char value truncation)
- `RateLimitError` now re-exported from `@loglayer/transport-http`
- Replaced manual pass-through of every config field with `{ ...config, ...overrides }`
- Updated unit tests to mock `HttpTransport`
- Disabled batch sending in livetest to ensure all logs flush before exit
- Updated docs with migration guide and Next.js Edge tip
- Removed redundant "Best Practices" and "TypeScript Support" sections
- Bumped version to `4.0.0`

## Breaking Changes

| v3.x | v4.x |
|------|------|
| `useCompression` | `compression` |
| `RateLimitError` from this package | `RateLimitError` re-exported from `@loglayer/transport-http` |

## New Features

- **Bun** and **Deno** compatibility
- **Batch sending** (enabled by default, inherited from HttpTransport)
- **`onDebugReqRes`** callback for HTTP-level debugging
- **Next.js Edge** runtime support (with `enableNextJsEdgeCompat`)