### PR TITLE
fix(ci): clear .npmrc to enable OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           title: 'chore: release package(s)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ''
 
   deploy-docs:
     needs: release


### PR DESCRIPTION
## Summary

One-line fix to enable npm OIDC trusted publishing.

### Root cause

`changesets/action` overwrites `.npmrc` with an `undefined` auth token when `NPM_TOKEN` is not set, breaking npm OIDC trusted publishing. Setting `NPM_TOKEN` to an empty string tells the action to skip `.npmrc` auth handling, allowing npm to use OIDC via `id-token: write`.

### References

- [changesets/action#542](https://github.com/changesets/action/issues/542) — Support Trusted Publishing
- [changesets/action#545](https://github.com/changesets/action/pull/545) — fix: conditionally append NPM_TOKEN to .npmrc (merged v1.7.0)

### What this fixes

The previous workflow (PR #374) set up OIDC correctly (`id-token: write`, Node 22, `registry-url`), but `changesets/action` still created a `.npmrc` with an invalid token, causing E404 on publish.

After merge, re-run the failed workflow run and `@loglayer/transport-new-relic@5.0.0` should publish successfully.