### PR TITLE
fix(ci): clear npm auth so OIDC trusted publishing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Prepare npm for OIDC
+        run: |
+          npm install -g npm@latest
+          rm -f ~/.npmrc
 
       - name: Install turbo
         run: pnpm install turbo --global
@@ -67,6 +71,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ''
+          NODE_AUTH_TOKEN: ''
 
   deploy-docs:
     needs: release


### PR DESCRIPTION
## Summary

Fixes the E404 on `@loglayer/transport-new-relic@4.0.0` publish.

### Root cause

`setup-node` with `registry-url` creates `~/.npmrc` and sets `NODE_AUTH_TOKEN` with a GitHub Packages token. npm uses that auth **instead of OIDC**, causing E404 on `registry.npmjs.org`.

Even with `NPM_TOKEN: ` (PR #375), the GitHub token in `.npmrc` takes precedence over OIDC.

### Fix

- Remove `registry-url` from `setup-node` so it no longer configures npm auth
- Add step to upgrade npm and delete `~/.npmrc` before changesets runs
- Set `NODE_AUTH_TOKEN: '' in changesets step so it's not inherited by the publish command

### References

- [changesets/action#542](https://github.com/changesets/action/issues/542)