### PR TITLE
fix(ci): remove broken npm self-upgrade from OIDC prepare step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,7 @@ jobs:
           node-version: 22
 
       - name: Prepare npm for OIDC
-        run: |
-          npm install -g npm@latest
-          rm -f ~/.npmrc
+        run: rm -f ~/.npmrc
 
       - name: Install turbo
         run: pnpm install turbo --global


### PR DESCRIPTION
## Problem

Run 25721729172 failed in the **Prepare npm for OIDC** step:

```
npm error Cannot find module 'promise-retry'
npm error MODULE_NOT_FOUND
```

The `npm install -g npm@latest` command was corrupting the npm binary on the runner, replacing it with an incomplete installation.

## Fix

Remove the `npm install -g npm@latest` step. Node 22 on `ubuntu-latest` ships with a sufficient npm version. The remaining OIDC preparation is enough:

1. `rm -f ~/.npmrc` — removes any GitHub Packages credentials from setup-node
2. `NODE_AUTH_TOKEN: ''` — prevents its GitHub token from overriding OIDC
3. `NPM_TOKEN: ''` — tells changesets/action to skip .npmrc modification (per PR #545)
4. `id-token: write` — enables OIDC token exchange
