### PR TITLE
fix(ci): upgrade to node 24 for npm 11.5.1 OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Prepare npm for OIDC
-        run: rm -f ~/.npmrc
+        run: |
+          echo "npm version: $(npm --version)"
+          rm -f ~/.npmrc
 
       - name: Install turbo
         run: pnpm install turbo --global


### PR DESCRIPTION
## Summary

Bumps **actions/setup-node from Node 22 → Node 24** to get **npm 11.5.1+** which supports native OIDC trusted publishing.

## Root Cause

Node 22 ships with npm 10.x which does **not** support npm OIDC trusted publishing. This caused `ENEEDAUTH` errors during publish despite:
- `id-token: write` permissions
- `NPM_TOKEN: ''` workaround
- `rm -f ~/.npmrc` cleanup

## Changes

- `node-version: 24` in `.github/workflows/release.yml`
- Adds `npm --version` echo in the Prepare step for debugging

## References

- [`setup-node` issue #1440](https://github.com/actions/setup-node/issues/1440) — "Don't default NODE_AUTH_TOKEN to support NPM OIDC"
- [changesets/`changesets` #1152](https://github.com/changesets/changesets/issues/1152) — trusted publishing workaround discussion
- [GitHub community #176761](https://github.com/orgs/community/discussions/176761) — runner image / NODE_AUTH_TOKEN discussion