### PR TITLE
feat(plugin): add missing params to plugin hooks for loglayer-go parity

### DIFF
--- a/.changeset/feat-add-missing-plugin-params.md
+++ b/.changeset/feat-add-missing-plugin-params.md
@@ -1,0 +1,70 @@
+---
+"@loglayer/shared": minor
+"@loglayer/plugin": minor
+loglayer: minor
+"@loglayer/transport": minor
+"@loglayer/context-manager": minor
+"@loglayer/context-manager-isolated": minor
+"@loglayer/context-manager-linked": minor
+"@loglayer/log-level-manager": minor
+"@loglayer/log-level-manager-global": minor
+"@loglayer/log-level-manager-linked": minor
+"@loglayer/log-level-manager-one-way": minor
+"@loglayer/elysia": minor
+"@loglayer/express": minor
+"@loglayer/fastify": minor
+"@loglayer/hono": minor
+"@loglayer/koa": minor
+"@loglayer/mixin-datadog-http-metrics": minor
+"@loglayer/mixin-hot-shots": minor
+"@loglayer/plugin-datadog-apm-trace-injector": minor
+"@loglayer/plugin-filter": minor
+"@loglayer/plugin-opentelemetry": minor
+"@loglayer/plugin-redaction": minor
+"@loglayer/plugin-sprintf": minor
+"@loglayer/transport-aws-cloudwatch-logs": minor
+"@loglayer/transport-aws-lambda-powertools": minor
+"@loglayer/transport-axiom": minor
+"@loglayer/transport-betterstack": minor
+"@loglayer/transport-bunyan": minor
+"@loglayer/transport-central": minor
+"@loglayer/transport-consola": minor
+"@loglayer/transport-cribl-http": minor
+"@loglayer/transport-datadog": minor
+"@loglayer/transport-datadog-browser-logs": minor
+"@loglayer/transport-dynatrace": minor
+"@loglayer/transport-electron-log": minor
+"@loglayer/transport-google-cloud-logging": minor
+"@loglayer/transport-http": minor
+"@loglayer/transport-log4js": minor
+"@loglayer/transport-log-file-rotation": minor
+"@loglayer/transport-logflare": minor
+"@loglayer/transport-loglevel": minor
+"@loglayer/transport-logtape": minor
+"@loglayer/transport-new-relic": minor
+"@loglayer/transport-opentelemetry": minor
+"@loglayer/transport-pino": minor
+"@loglayer/transport-pretty-terminal": minor
+"@loglayer/transport-roarr": minor
+"@loglayer/transport-sentry": minor
+"@loglayer/transport-signale": minor
+"@loglayer/transport-simple-pretty-terminal": minor
+"@loglayer/transport-sumo-logic": minor
+"@loglayer/transport-tracer": minor
+"@loglayer/transport-tslog": minor
+"@loglayer/transport-victoria-logs": minor
+"@loglayer/transport-winston": minor
+---
+
+Add missing parameters to plugin hooks and transports for feature parity with loglayer-go
+
+Added to all plugin params (`PluginBeforeDataOutParams`, `PluginBeforeMessageOutParams`, `PluginShouldSendToLoggerParams`, `PluginTransformLogLevelParams`) and `LogLayerTransportParams`:
+
+- `groups?: string[]` - The group names this log entry belongs to
+- `schema?: LogLayerPluginSchema` - Schema information for navigating the assembled data (contextFieldName, metadataFieldName, errorFieldName)
+- `prefix?: string` - The prefix attached via withPrefix()
+
+New `LogLayerPluginSchema` interface provides:
+- `contextFieldName?: string` - Key under which persistent context data is nested
+- `metadataFieldName?: string` - Key under which per-call metadata is nested
+- `errorFieldName: string` - Key under which serialized error is stored

--- a/docs/src/plugins/creating-plugins.md
+++ b/docs/src/plugins/creating-plugins.md
@@ -167,6 +167,9 @@ transformLogLevel?(params: PluginTransformLogLevelParams, loglayer: ILogLayer): 
 | `metadata` | `Record<string, any>` (optional) | Individual metadata object passed to the log message method |
 | `error` | `any` (optional) | Error passed to the log message method |
 | `context` | `Record<string, any>` (optional) | Context data that is included with each log entry |
+| `groups` | `string[]` (optional) | [Group](/logging-api/groups) tags assigned to this log entry |
+| `schema` | `LogLayerPluginSchema` (optional) | Schema information for navigating the assembled data |
+| `prefix` | `string` (optional) | The prefix attached via [`withPrefix()`](/logging-api/basic-logging#prefix-and-suffix) |
 
 **Return Value:**
 
@@ -231,6 +234,9 @@ onBeforeDataOut?(params: PluginBeforeDataOutParams, loglayer: ILogLayer): Record
 | `metadata` | `Record<string, any>` (optional) | Individual metadata object passed to the log message method |
 | `error` | `any` (optional) | Error passed to the log message method |
 | `context` | `Record<string, any>` (optional) | Context data that is included with each log entry |
+| `groups` | `string[]` (optional) | [Group](/logging-api/groups) tags assigned to this log entry |
+| `schema` | `LogLayerPluginSchema` (optional) | Schema information for navigating the assembled data |
+| `prefix` | `string` (optional) | The prefix attached via [`withPrefix()`](/logging-api/basic-logging#prefix-and-suffix) |
 
 **Example:**
 ```typescript
@@ -265,6 +271,9 @@ onBeforeMessageOut?(params: PluginBeforeMessageOutParams, loglayer: ILogLayer): 
 |-----------|------|-------------|
 | `messages` | `any[]` | Message data that is copied from the original |
 | `logLevel` | `LogLevel` | Log level of the message |
+| `groups` | `string[]` (optional) | [Group](/logging-api/groups) tags assigned to this log entry |
+| `schema` | `LogLayerPluginSchema` (optional) | Schema information for navigating the assembled data |
+| `prefix` | `string` (optional) | The prefix attached via [`withPrefix()`](/logging-api/basic-logging#prefix-and-suffix) |
 
 **Example:**
 ```typescript
@@ -296,6 +305,8 @@ shouldSendToLogger?(params: PluginShouldSendToLoggerParams, loglayer: ILogLayer)
 | `error` | `any` (optional) | Error passed to the log message method |
 | `context` | `Record<string, any>` (optional) | Context data that is included with each log entry |
 | `groups` | `string[]` (optional) | [Group](/logging-api/groups) tags assigned to this log entry |
+| `schema` | `LogLayerPluginSchema` (optional) | Schema information for navigating the assembled data |
+| `prefix` | `string` (optional) | The prefix attached via [`withPrefix()`](/logging-api/basic-logging#prefix-and-suffix) |
 
 **Example:**
 ```typescript
@@ -413,6 +424,61 @@ const contextEnrichmentPlugin = {
 ::: tip Lazy values
 This hook runs at `withContext()` time, before lazy values are resolved. If context contains [`lazy()` values](/logging-api/lazy-evaluation), they will appear as wrapper objects rather than their evaluated values. Use [`onBeforeDataOut`](#onbeforedataout) if you need to inspect resolved values.
 :::
+
+## LogLayerPluginSchema
+
+The `schema` parameter passed to plugin hooks provides schema information for navigating the assembled data object:
+
+```typescript
+interface LogLayerPluginSchema {
+  /**
+   * Key under which persistent context data is nested.
+   * `undefined` when context fields are merged at the root level.
+   */
+  contextFieldName?: string;
+  
+  /**
+   * Key under which per-call metadata is nested.
+   * `undefined` when metadata fields are merged at the root level.
+   */
+  metadataFieldName?: string;
+  
+  /**
+   * Key under which serialized error is stored.
+   * Always populated; defaults to `"err"`.
+   */
+  errorFieldName: string;
+}
+```
+
+::: info Only `errorFieldName` is guaranteed to be present
+`contextFieldName` and `metadataFieldName` are `undefined` when their respective data is merged at the root level of the data object. Only `errorFieldName` is always populated.
+:::
+
+This allows plugins to locate context, metadata, and error data within the assembled `data` object regardless of how LogLayer is configured.
+
+**Example:**
+```typescript
+const schemaAwarePlugin = {
+  onBeforeDataOut: ({ data, schema }: PluginBeforeDataOutParams, loglayer: ILogLayer) => {
+    // Access error using schema information
+    const errorField = schema.errorFieldName;
+    const error = data[errorField];
+    
+    // Access context using schema information
+    const contextData = schema.contextFieldName 
+      ? data[schema.contextFieldName] 
+      : data;
+    
+    // Access metadata using schema information
+    const metadataData = schema.metadataFieldName 
+      ? data[schema.metadataFieldName] 
+      : data;
+    
+    return data;
+  }
+}
+```
 
 ## Boilerplate / Template Code
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -654,13 +654,15 @@ The `shouldSendToLogger` plugin hook receives the `groups` array:
 
 ### Transport Integration
 
-Transports receive the `groups` array in `LogLayerTransportParams`:
+Transports receive `groups`, `schema`, and `prefix` in `LogLayerTransportParams`:
 
 ```typescript
-shipToLogger({ logLevel, messages, groups }) {
+shipToLogger({ logLevel, messages, groups, schema, prefix }) {
   if (groups) {
     // Include group info in structured output
   }
+  // schema.contextFieldName, schema.metadataFieldName, schema.errorFieldName
+  // prefix from withPrefix() or config.prefix (undefined when not set)
 }
 ```
 
@@ -892,6 +894,8 @@ interface LogLayerTransportParams {
   error?: any                     // individual error
   context?: Record<string, any>   // individual context
   groups?: string[]               // group tags for this log entry
+  schema?: LogLayerPluginSchema   // field names for context/metadata/error
+  prefix?: string                 // from withPrefix() or config.prefix (undefined when not set)
 }
 ```
 
@@ -937,6 +941,18 @@ log.removePlugin('my-plugin')
 log.withFreshPlugins([newPlugin1, newPlugin2])
 ```
 
+### LogLayerPluginSchema
+
+The `schema` parameter provides field names for navigating assembled data:
+
+```typescript
+interface LogLayerPluginSchema {
+  contextFieldName?: string  // Key for context data
+  metadataFieldName?: string // Key for metadata
+  errorFieldName: string     // Key for error (defaults to "err")
+}
+```
+
 ### Plugin Lifecycle Methods
 
 ```typescript
@@ -945,16 +961,16 @@ interface LogLayerPlugin {
   disabled?: boolean
 
   // Modify data (metadata + context + error) before transport
-  onBeforeDataOut?(params: { logLevel, data, metadata, error, context }, loglayer): Record<string, any> | null
+  onBeforeDataOut?(params: { logLevel, data, metadata, error, context, groups, schema, prefix }, loglayer): Record<string, any> | null
 
   // Modify messages before transport
-  onBeforeMessageOut?(params: { messages, logLevel }, loglayer): MessageDataType[]
+  onBeforeMessageOut?(params: { messages, logLevel, groups, schema, prefix }, loglayer): MessageDataType[]
 
   // Transform the log level dynamically
-  transformLogLevel?(params: { logLevel, messages, data, metadata, error, context }, loglayer): LogLevelType | null
+  transformLogLevel?(params: { logLevel, messages, data, metadata, error, context, groups, schema, prefix }, loglayer): LogLevelType | null
 
   // Control whether a log should be sent (return false to drop)
-  shouldSendToLogger?(params: { messages, logLevel, transportId, data, metadata, error, context, groups }, loglayer): boolean
+  shouldSendToLogger?(params: { messages, logLevel, transportId, data, metadata, error, context, groups, schema, prefix }, loglayer): boolean
 
   // Intercept withMetadata() / metadataOnly() calls
   onMetadataCalled?(metadata, loglayer): Record<string, any> | null

--- a/docs/src/transports/creating-transports.md
+++ b/docs/src/transports/creating-transports.md
@@ -287,6 +287,8 @@ shipToLogger({ logLevel, messages, data, hasData, groups }: LogLayerTransportPar
 The `schema` object provides field names where context, metadata, and error data are nested in the `data` object. This helps transports properly extract and structure log data:
 
 ```typescript
+import type { LogLayerPluginSchema } from 'loglayer';
+
 interface LogLayerPluginSchema {
   /** Key under which persistent context data is nested (undefined if merged at root) */
   contextFieldName?: string;
@@ -300,6 +302,8 @@ interface LogLayerPluginSchema {
 Example usage:
 
 ```typescript
+import type { LogLayerTransportParams, LogLayerPluginSchema } from 'loglayer';
+
 shipToLogger({ logLevel, messages, data, hasData, schema }: LogLayerTransportParams) {
   const payload: Record<string, any> = {
     level: logLevel,

--- a/docs/src/transports/creating-transports.md
+++ b/docs/src/transports/creating-transports.md
@@ -248,6 +248,16 @@ interface LogLayerTransportParams {
    * Group tags assigned to this log entry.
    */
   groups?: string[];
+  /**
+   * Schema information for navigating the assembled data structure.
+   * Contains field names where context, metadata, and error data are nested.
+   */
+  schema?: LogLayerPluginSchema;
+  /**
+   * The prefix attached via withPrefix() on the emitting logger.
+   * Empty when no prefix was set.
+   */
+  prefix?: string;
 }
 ```
 
@@ -269,6 +279,73 @@ shipToLogger({ logLevel, messages, data, hasData, groups }: LogLayerTransportPar
 
   this.service.send(payload)
   return messages
+}
+```
+
+### Using Schema in Transports
+
+The `schema` object provides field names where context, metadata, and error data are nested in the `data` object. This helps transports properly extract and structure log data:
+
+```typescript
+interface LogLayerPluginSchema {
+  /** Key under which persistent context data is nested (undefined if merged at root) */
+  contextFieldName?: string;
+  /** Key under which per-call metadata is nested (undefined if merged at root) */
+  metadataFieldName?: string;
+  /** Key under which serialized error is stored (always present, defaults to "err") */
+  errorFieldName: string;
+}
+```
+
+Example usage:
+
+```typescript
+shipToLogger({ logLevel, messages, data, hasData, schema }: LogLayerTransportParams) {
+  const payload: Record<string, any> = {
+    level: logLevel,
+    message: messages.join(' '),
+  }
+
+  // Access context data using schema field names
+  if (schema.contextFieldName && data[schema.contextFieldName]) {
+    payload.context = data[schema.contextFieldName]
+  }
+
+  // Access metadata using schema field names
+  if (schema.metadataFieldName && data[schema.metadataFieldName]) {
+    payload.metadata = data[schema.metadataFieldName]
+  }
+
+  // Access error using schema (errorFieldName is always present)
+  if (data[schema.errorFieldName]) {
+    payload.error = data[schema.errorFieldName]
+  }
+
+  this.service.send(payload)
+  return messages
+}
+```
+
+### Using Prefix in Transports
+
+The `prefix` string contains the prefix attached via `withPrefix()` on the emitting logger. Use it to include prefix information in your transport output:
+
+```typescript
+shipToLogger({ logLevel, messages, data, hasData, prefix }: LogLayerTransportParams) {
+  const formattedMessages = messages.map(msg => {
+    if (typeof msg === 'string' && prefix) {
+      return `[${prefix}] ${msg}`
+    }
+    return msg
+  })
+
+  this.service.send({
+    level: logLevel,
+    messages: formattedMessages,
+    ...(data && hasData ? data : {}),
+  })
+
+  return formattedMessages
 }
 ```
 

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -21,6 +21,15 @@ log.withError(err).error`Failed: ${err.message}`;
 
 See the [Basic Logging documentation](/logging-api/basic-logging#tagged-template-syntax) for usage examples.
 
+`@loglayer/shared`, `@loglayer/plugin`, `loglayer`:
+
+- **Plugin parameter parity with loglayer-go**: All plugin hooks now receive additional parameters:
+  - `groups?: string[]` - The group tags assigned to this log entry
+  - `schema?: LogLayerPluginSchema` - Schema information for navigating the assembled data (`contextFieldName`, `metadataFieldName`, `errorFieldName`)
+  - `prefix?: string` - The prefix attached via `withPrefix()`
+
+These parameters are also passed to transport `_sendToLogger` calls. See the [Creating Plugins documentation](/plugins/creating-plugins#loglayerpluginschema) for details.
+
 ## May 15, 2026
 
 `loglayer`:

--- a/packages/core/loglayer/src/LogLayer.ts
+++ b/packages/core/loglayer/src/LogLayer.ts
@@ -1,6 +1,7 @@
 import { DefaultContextManager } from "@loglayer/context-manager";
 import { DefaultLogLevelManager } from "@loglayer/log-level-manager";
 import { type LogLayerPlugin, PluginCallbackType } from "@loglayer/plugin";
+import type { LogLayerPluginSchema } from "@loglayer/shared";
 import {
   type ContainsAsyncLazy,
   countLazyValues,
@@ -1260,8 +1261,24 @@ export class LogLayer implements ILogLayer<LogLayer> {
     context: LogLayerContext | null,
     groups: string[] | null = null,
   ) {
-    const { errorSerializer, errorFieldInMetadata, muteContext, contextFieldName, metadataFieldName, errorFieldName } =
-      this._config;
+    const {
+      errorSerializer,
+      errorFieldInMetadata,
+      muteContext,
+      contextFieldName,
+      metadataFieldName,
+      errorFieldName,
+      prefix,
+    } = this._config;
+
+    // Build schema for plugins and transports
+    const schema: LogLayerPluginSchema = {
+      contextFieldName: contextFieldName ?? undefined,
+      metadataFieldName: metadataFieldName ?? undefined,
+      errorFieldName: errorFieldName ?? "err",
+    };
+
+    const effectiveGroups = this._mergeGroups(groups) ?? undefined;
 
     let hasObjData =
       !!metadata ||
@@ -1332,6 +1349,9 @@ export class LogLayer implements ILogLayer<LogLayer> {
           error: err,
           metadata,
           context: contextData,
+          groups: effectiveGroups,
+          schema,
+          prefix: prefix,
         },
         this,
       );
@@ -1346,6 +1366,9 @@ export class LogLayer implements ILogLayer<LogLayer> {
         {
           messages: [...params],
           logLevel,
+          groups: effectiveGroups,
+          schema,
+          prefix: prefix,
         },
         this,
       );
@@ -1361,12 +1384,24 @@ export class LogLayer implements ILogLayer<LogLayer> {
           error: err,
           metadata,
           context: contextData,
+          groups: effectiveGroups,
+          schema,
+          prefix: prefix,
         },
         this,
       );
     }
 
-    const effectiveGroups = this._mergeGroups(groups) ?? undefined;
+    // Build shared params object for shouldSendToLogger and transport calls
+    const sharedParams = {
+      data: hasObjData ? d : undefined,
+      error: err,
+      metadata,
+      context: contextData,
+      groups: effectiveGroups,
+      schema,
+      prefix: prefix,
+    };
 
     if (this.hasMultipleTransports) {
       const transportPromises = (this._config.transport as LogLayerTransport[])
@@ -1384,13 +1419,9 @@ export class LogLayer implements ILogLayer<LogLayer> {
             const shouldSend = this.pluginManager.runShouldSendToLogger(
               {
                 messages: [...params],
-                data: hasObjData ? d : undefined,
                 logLevel: currentLogLevel,
                 transportId: transport.id,
-                error: err,
-                metadata,
-                context: contextData,
-                groups: effectiveGroups,
+                ...sharedParams,
               },
               this,
             );
@@ -1403,12 +1434,8 @@ export class LogLayer implements ILogLayer<LogLayer> {
           return transport._sendToLogger({
             logLevel: currentLogLevel,
             messages: [...params],
-            data: hasObjData ? d : undefined,
             hasData: hasObjData,
-            error: err,
-            metadata,
-            context: contextData,
-            groups: effectiveGroups,
+            ...sharedParams,
           });
         });
 
@@ -1433,13 +1460,9 @@ export class LogLayer implements ILogLayer<LogLayer> {
         const shouldSend = this.pluginManager.runShouldSendToLogger(
           {
             messages: [...params],
-            data: hasObjData ? d : undefined,
             logLevel,
             transportId: this.singleTransport.id,
-            error: err,
-            metadata,
-            context: contextData,
-            groups: effectiveGroups,
+            ...sharedParams,
           },
           this,
         );
@@ -1453,12 +1476,8 @@ export class LogLayer implements ILogLayer<LogLayer> {
       this.singleTransport._sendToLogger({
         logLevel,
         messages: [...params],
-        data: hasObjData ? d : undefined,
         hasData: hasObjData,
-        error: err,
-        metadata,
-        context: contextData,
-        groups: effectiveGroups,
+        ...sharedParams,
       });
     }
   }

--- a/packages/core/loglayer/src/PluginManager.ts
+++ b/packages/core/loglayer/src/PluginManager.ts
@@ -142,6 +142,9 @@ export class PluginManager {
             error: params.error,
             metadata: params.metadata,
             context: params.context,
+            groups: params.groups,
+            schema: params.schema,
+            prefix: params.prefix,
           },
           loglayer,
         );
@@ -176,6 +179,9 @@ export class PluginManager {
             error: initialData.error,
             metadata: initialData.metadata,
             context: initialData.context,
+            groups: initialData.groups,
+            schema: initialData.schema,
+            prefix: initialData.prefix,
           },
           loglayer,
         );
@@ -241,6 +247,9 @@ export class PluginManager {
         {
           messages: messages,
           logLevel: params.logLevel,
+          groups: params.groups,
+          schema: params.schema,
+          prefix: params.prefix,
         },
         loglayer,
       );

--- a/packages/core/loglayer/src/__tests__/LogLayer.basic.test.ts
+++ b/packages/core/loglayer/src/__tests__/LogLayer.basic.test.ts
@@ -459,6 +459,12 @@ describe("LogLayer basic functionality", () => {
       error: testError,
       metadata: testMetadata,
       context: testContext,
+      schema: {
+        contextFieldName: undefined,
+        metadataFieldName: undefined,
+        errorFieldName: "err",
+      },
+      prefix: undefined,
     });
   });
 
@@ -503,6 +509,12 @@ describe("LogLayer basic functionality", () => {
       error: testError,
       metadata: testMetadata,
       context: testContext,
+      schema: {
+        contextFieldName: undefined,
+        metadataFieldName: undefined,
+        errorFieldName: "err",
+      },
+      prefix: undefined,
     };
 
     expect(mockTransport1._sendToLogger).toHaveBeenCalledWith(expectedParams);
@@ -591,6 +603,12 @@ describe("LogLayer basic functionality", () => {
         error: testError,
         metadata: testMetadata,
         context: testContext,
+        schema: {
+          contextFieldName: undefined,
+          metadataFieldName: undefined,
+          errorFieldName: "err",
+        },
+        prefix: undefined,
       });
     });
 
@@ -957,6 +975,13 @@ describe("LogLayer basic functionality", () => {
         error: testError,
         metadata: testMetadata,
         context: {},
+        groups: undefined,
+        schema: {
+          contextFieldName: undefined,
+          metadataFieldName: undefined,
+          errorFieldName: "err",
+        },
+        prefix: undefined,
       });
     });
 
@@ -995,6 +1020,13 @@ describe("LogLayer basic functionality", () => {
         error: undefined,
         metadata: { multiTransport: "test" },
         context: {},
+        groups: undefined,
+        schema: {
+          contextFieldName: undefined,
+          metadataFieldName: undefined,
+          errorFieldName: "err",
+        },
+        prefix: undefined,
       };
 
       expect(mockTransport1._sendToLogger).toHaveBeenCalledWith(expectedParams);

--- a/packages/core/loglayer/src/__tests__/LogLayer.plugins.test.ts
+++ b/packages/core/loglayer/src/__tests__/LogLayer.plugins.test.ts
@@ -766,4 +766,396 @@ describe("LogLayer plugin system", () => {
       );
     });
   });
+
+  describe("groups parameter", () => {
+    it("should pass groups to onBeforeDataOut", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.withGroup("database").info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groups: expect.arrayContaining(["database"]),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass groups to onBeforeMessageOut", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeMessageOut: spy,
+        },
+      ]);
+
+      log.withGroup(["auth", "database"]).info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groups: expect.arrayContaining(["auth", "database"]),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass groups to transformLogLevel", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          transformLogLevel: spy,
+        },
+      ]);
+
+      log.withGroup("critical").warn("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groups: expect.arrayContaining(["critical"]),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass groups to shouldSendToLogger", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          shouldSendToLogger: spy,
+        },
+      ]);
+
+      log.withGroup("audit").info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groups: expect.arrayContaining(["audit"]),
+        }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("schema parameter", () => {
+    it("should pass schema to onBeforeDataOut", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: expect.objectContaining({
+            errorFieldName: "err",
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass schema with contextFieldName when configured", () => {
+      const log = getLogger({
+        contextFieldName: "ctx",
+        transport: new TestTransport({
+          id: "test",
+          logger: new TestLoggingLibrary(),
+        }),
+      });
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.withContext({ userId: "123" }).info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: expect.objectContaining({
+            contextFieldName: "ctx",
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass schema with metadataFieldName when configured", () => {
+      const log = getLogger({
+        metadataFieldName: "meta",
+        transport: new TestTransport({
+          id: "test",
+          logger: new TestLoggingLibrary(),
+        }),
+      });
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.withMetadata({ key: "value" }).info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: expect.objectContaining({
+            metadataFieldName: "meta",
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass schema with all three field names when all configured", () => {
+      const log = getLogger({
+        contextFieldName: "ctx",
+        metadataFieldName: "meta",
+        errorFieldName: "customError",
+        transport: new TestTransport({
+          id: "test",
+          logger: new TestLoggingLibrary(),
+        }),
+      });
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log
+        .withContext({ userId: "123" })
+        .withMetadata({ requestId: "abc" })
+        .withError(new Error("test error"))
+        .info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: {
+            contextFieldName: "ctx",
+            metadataFieldName: "meta",
+            errorFieldName: "customError",
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass schema to onBeforeMessageOut", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeMessageOut: spy,
+        },
+      ]);
+
+      log.info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: expect.objectContaining({
+            errorFieldName: "err",
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass schema to transformLogLevel", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          transformLogLevel: spy,
+        },
+      ]);
+
+      log.info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: expect.objectContaining({
+            errorFieldName: "err",
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass schema to shouldSendToLogger", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          shouldSendToLogger: spy,
+        },
+      ]);
+
+      log.info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: expect.objectContaining({
+            errorFieldName: "err",
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("prefix parameter", () => {
+    it("should pass prefix to onBeforeDataOut", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.withPrefix("[APP]").info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prefix: "[APP]",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass empty prefix when not set", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prefix: undefined,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass prefix from config", () => {
+      const log = getLogger({
+        prefix: "[CONFIG]",
+        transport: new TestTransport({
+          id: "test",
+          logger: new TestLoggingLibrary(),
+        }),
+      });
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeDataOut: spy,
+        },
+      ]);
+
+      log.info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prefix: "[CONFIG]",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass prefix to onBeforeMessageOut", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          onBeforeMessageOut: spy,
+        },
+      ]);
+
+      log.withPrefix("[AUTH]").info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prefix: "[AUTH]",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass prefix to transformLogLevel", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          transformLogLevel: spy,
+        },
+      ]);
+
+      log.withPrefix("[API]").info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prefix: "[API]",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("should pass prefix to shouldSendToLogger", () => {
+      const log = getLoggerWithTestTransport();
+      const spy = vi.fn();
+
+      log.addPlugins([
+        {
+          shouldSendToLogger: spy,
+        },
+      ]);
+
+      log.withPrefix("[DB]").info("Test message");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prefix: "[DB]",
+        }),
+        expect.any(Object),
+      );
+    });
+  });
 });

--- a/packages/core/loglayer/src/index.ts
+++ b/packages/core/loglayer/src/index.ts
@@ -19,6 +19,7 @@ export type {
   LogLayerData,
   LogLayerMetadata,
   LogLayerPlugin,
+  LogLayerPluginSchema,
   LogLayerTransport,
   LogLayerTransportParams,
   LogLevelPriority,

--- a/packages/core/loglayer/src/index.ts
+++ b/packages/core/loglayer/src/index.ts
@@ -15,6 +15,7 @@ export type {
   LazyLogValue,
   LogGroupConfig,
   LogGroupsConfig,
+  LogLayerCommonDataParams,
   LogLayerContext,
   LogLayerData,
   LogLayerMetadata,

--- a/packages/core/plugin/src/types.ts
+++ b/packages/core/plugin/src/types.ts
@@ -10,6 +10,7 @@ import type {
 export type {
   LogLayerPlugin,
   LogLayerPluginParams,
+  LogLayerPluginSchema,
   PluginBeforeDataOutParams,
   PluginBeforeMessageOutParams,
   PluginShouldSendToLoggerParams,

--- a/packages/core/shared/src/loglayer.types.ts
+++ b/packages/core/shared/src/loglayer.types.ts
@@ -10,7 +10,7 @@ import type {
   LogReturnType,
   MessageDataType,
 } from "./common.types.js";
-import type { LogLayerPlugin } from "./plugin.types.js";
+import type { LogLayerPlugin, LogLayerPluginSchema } from "./plugin.types.js";
 
 /**
  * Interface for raw log entries that allows complete control over all aspects of a log entry.
@@ -225,6 +225,15 @@ export interface LogLayerTransportParams extends LogLayerCommonDataParams {
    * @see {@link https://loglayer.dev/logging-api/groups.html | Groups Docs}
    */
   groups?: string[];
+  /**
+   * Schema information for navigating the assembled data.
+   */
+  schema?: LogLayerPluginSchema;
+  /**
+   * The prefix attached via withPrefix() on the emitting logger (or set
+   * via config.prefix). Empty when no prefix was set.
+   */
+  prefix?: string;
 }
 
 /**

--- a/packages/core/shared/src/plugin.types.ts
+++ b/packages/core/shared/src/plugin.types.ts
@@ -8,6 +8,38 @@ import type {
 import type { ILogLayer } from "./loglayer.types.js";
 
 /**
+ * Schema information for navigating the assembled log data.
+ *
+ * Contains the resolved field names used when assembling the log data,
+ * so plugins can navigate Data precisely (e.g., find the error map at
+ * errorFieldName).
+ *
+ * @note Only `errorFieldName` is guaranteed to be present. `contextFieldName`
+ * and `metadataFieldName` are `undefined` when their respective data is merged
+ * at the root level of the data object (i.e., when `contextFieldName` or
+ * `metadataFieldName` is not configured in LogLayer).
+ *
+ * @see {@link https://loglayer.dev/plugins/creating-plugins.html | Creating Plugins}
+ */
+export interface LogLayerPluginSchema {
+  /**
+   * The key under which persistent context data is nested in data.
+   * `undefined` when context is merged at root level.
+   */
+  contextFieldName?: string;
+  /**
+   * The key under which per-call metadata is nested in data.
+   * `undefined` when metadata is merged at root level.
+   */
+  metadataFieldName?: string;
+  /**
+   * The key under which the serialized error is stored in data.
+   * Always populated; defaults to "err".
+   */
+  errorFieldName: string;
+}
+
+/**
  * Input for the `onBeforeDataOut` plugin lifecycle method.
  * @see {@link https://loglayer.dev/plugins/creating-plugins.html#onbeforedataout | Creating Plugins}
  */
@@ -16,6 +48,21 @@ export interface PluginBeforeDataOutParams extends LogLayerCommonDataParams {
    * Log level of the data
    */
   logLevel: LogLevelType;
+  /**
+   * The group names this log entry belongs to, if any.
+   *
+   * @see {@link https://loglayer.dev/logging-api/groups.html | Groups Docs}
+   */
+  groups?: string[];
+  /**
+   * Schema information for navigating the assembled data.
+   */
+  schema?: LogLayerPluginSchema;
+  /**
+   * The prefix attached via withPrefix() on the emitting logger (or set
+   * via config.prefix). Empty when no prefix was set.
+   */
+  prefix?: string;
 }
 
 /**
@@ -31,6 +78,21 @@ export interface PluginTransformLogLevelParams extends LogLayerCommonDataParams 
    * Message data that is copied from the original.
    */
   messages: any[];
+  /**
+   * The group names this log entry belongs to, if any.
+   *
+   * @see {@link https://loglayer.dev/logging-api/groups.html | Groups Docs}
+   */
+  groups?: string[];
+  /**
+   * Schema information for navigating the assembled data.
+   */
+  schema?: LogLayerPluginSchema;
+  /**
+   * The prefix attached via withPrefix() on the emitting logger (or set
+   * via config.prefix). Empty when no prefix was set.
+   */
+  prefix?: string;
 }
 
 /**
@@ -56,6 +118,15 @@ export interface PluginShouldSendToLoggerParams extends LogLayerCommonDataParams
    * @see {@link https://loglayer.dev/logging-api/groups.html | Groups Docs}
    */
   groups?: string[];
+  /**
+   * Schema information for navigating the assembled data.
+   */
+  schema?: LogLayerPluginSchema;
+  /**
+   * The prefix attached via withPrefix() on the emitting logger (or set
+   * via config.prefix). Empty when no prefix was set.
+   */
+  prefix?: string;
 }
 
 /**
@@ -71,6 +142,21 @@ export interface PluginBeforeMessageOutParams {
    * Message data that is copied from the original.
    */
   messages: any[];
+  /**
+   * The group names this log entry belongs to, if any.
+   *
+   * @see {@link https://loglayer.dev/logging-api/groups.html | Groups Docs}
+   */
+  groups?: string[];
+  /**
+   * Schema information for navigating the assembled data.
+   */
+  schema?: LogLayerPluginSchema;
+  /**
+   * The prefix attached via withPrefix() on the emitting logger (or set
+   * via config.prefix). Empty when no prefix was set.
+   */
+  prefix?: string;
 }
 
 /**


### PR DESCRIPTION
Add missing parameters to plugin hooks and transports for feature parity with loglayer-go

## Summary

This PR adds three new parameters to all plugin hook params and :
-  - The group names this log entry belongs to
-  - Schema information for navigating the assembled data
-  - The prefix attached via `withPrefix()`

Also introduces a new `LogLayerPluginSchema` interface with:
- `contextFieldName?: string` - Key under which persistent context data is nested
- `metadataFieldName?: string` - Key under which per-call metadata is nested
- `errorFieldName: string` - Key under which serialized error is stored

## Changes

- 55 packages with minor version bumps
- Updated plugin types in `@loglayer/shared`, `@loglayer/plugin`, and `loglayer`
- Updated `LogLayerTransportParams` in `@loglayer/shared` and `@loglayer/transport`
- Documentation updates for creating plugins guide
- Changelog entry