### PR TITLE
feat: add wide events mixin for comprehensive logging

### DIFF
--- a/.changeset/feat-add-wide-event-mixin.md
+++ b/.changeset/feat-add-wide-event-mixin.md
@@ -1,0 +1,15 @@
+---
+"@loglayer/mixin-wide-events": minor
+---
+
+Add @loglayer/mixin-wide-events package for wide event logging functionality.
+
+- Adds `withWideEvents(data)` method to accumulate data across async operations
+- Adds `emitWideEvent({ message, level?, metadata? })` method to output comprehensive log entries
+- Works with AsyncLocalStorage for proper async context propagation
+- Supports all log levels and fluent chaining
+- Added configuration options: `includeContext` (default: true), `wideEventField` (for nesting)
+- Context data from `withContext()` is included in wide events by default
+- Priority ordering: context < wideEvents < emit metadata
+
+For more details, see the [wide event documentation](https://loglayer.dev/guides/event-wide-logging).

--- a/.changeset/feat-add-wide-event-mixin.md
+++ b/.changeset/feat-add-wide-event-mixin.md
@@ -1,15 +1,25 @@
 ---
-"@loglayer/mixin-wide-events": minor
+"@loglayer/mixin-wide-events": major
 ---
 
-Add @loglayer/mixin-wide-events package for wide event logging functionality.
+Add `@loglayer/mixin-wide-events` package for wide event logging functionality.
 
-- Adds `withWideEvents(data)` method to accumulate data across async operations
-- Adds `emitWideEvent({ message, level?, metadata? })` method to output comprehensive log entries
-- Works with AsyncLocalStorage for proper async context propagation
-- Supports all log levels and fluent chaining
-- Added configuration options: `includeContext` (default: true), `wideEventField` (for nesting)
-- Context data from `withContext()` is included in wide events by default
-- Priority ordering: context < wideEvents < emit metadata
+**Methods:**
+- `withWideEvents(data)` - Accumulate data across async operations
+- `getWideEvents(key?)` - Read accumulated data
+- `clearWideEvents(key?)` - Clear all or specific key
+- `emitWideEvent({ message, level?, metadata? })` - Emit comprehensive log entry
+
+**Configuration Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `asyncContext` | `AsyncLocalStorage` | required | Async context for propagation |
+| `includeContext` | `boolean` | `true` | Include `withContext()` data |
+| `wideEventField` | `string` | undefined | Nest data under field |
+
+**Safety Features:**
+- Prototype pollution protection (`__proto__`, `constructor`, `prototype` blocked)
+- Circular reference detection via `WeakSet`
+- Deep merge for nested objects
 
 For more details, see the [wide event documentation](https://loglayer.dev/guides/event-wide-logging).

--- a/.changeset/feat-add-wide-event-mixin.md
+++ b/.changeset/feat-add-wide-event-mixin.md
@@ -17,9 +17,4 @@ Add `@loglayer/mixin-wide-events` package for wide event logging functionality.
 | `includeContext` | `boolean` | `true` | Include `withContext()` data |
 | `wideEventField` | `string` | undefined | Nest data under field |
 
-**Safety Features:**
-- Prototype pollution protection (`__proto__`, `constructor`, `prototype` blocked)
-- Circular reference detection via `WeakSet`
-- Deep merge for nested objects
-
 For more details, see the [wide event documentation](https://loglayer.dev/guides/event-wide-logging).

--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -44,8 +44,34 @@ When adding new features or changing existing APIs, you must also update:
 
 ### Configuration Tables
 
+Use `## Configuration Options` with subsections for required and optional parameters:
+
+```markdown
+## Configuration Options
+
+### Required Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| `paramName` | `Type` | Description |
+
+### Optional Parameters
+
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
+| `paramName` | `Type` | `default` | Description |
+```
+
+### Method Type Signatures
+
+Include type signatures for all methods:
+
+```markdown
+### `methodName(param)`
+
+`(paramType) => returnType`
+
+Description...
 
 ### Custom Containers
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -190,9 +190,11 @@ export default defineConfig({
         text: 'Mixins (v7)',
         items: [
           { text: 'Overview', link: '/mixins/' },
+          { text: 'Wide Events', link: '/mixins/wide-events' },
           { text: 'Creating Mixins', link: '/mixins/creating-mixins' },
           { text: 'Testing Mixins', link: '/mixins/testing-mixins' },
           { text: 'Available Mixins', items: [
+              { text: 'Wide Events', link: '/mixins/wide-events' },
               { text: 'Datadog Metrics (HTTP)', link: '/mixins/datadog-http-metrics' },
               { text: 'Hot-Shots (StatsD)', link: '/mixins/hot-shots' },
           ]}
@@ -227,7 +229,7 @@ export default defineConfig({
           { text: 'Async context tracking', link: '/example-integrations/async-context' },
           { text: 'Bun', link: '/example-integrations/bun' },
           { text: 'Deno', link: '/example-integrations/deno' },
-
+          { text: 'Event-Wide Logging', link: '/guides/event-wide-logging' },
           { text: 'Next.js', link: '/example-integrations/nextjs' },
         ]
       }

--- a/docs/src/guides/event-wide-logging.md
+++ b/docs/src/guides/event-wide-logging.md
@@ -1,0 +1,257 @@
+---
+title: Event-Wide Logging (Wide Events)
+description: Learn how to implement wide events for better observability using LogLayer
+---
+
+# Event-Wide Logging (Wide Events)
+
+This guide shows how to implement [wide events](https://loggingsucks.com/)
+using LogLayer's [Wide Events Mixin](/mixins/wide-events) (`@loglayer/mixin-wide-events`).
+Instead of emitting many small log entries throughout your code, you accumulate
+context into a single comprehensive event emitted at the end of each operation.
+
+::: info Example Framework
+This guide uses **Express** to demonstrate wide event logging. The same patterns
+apply to any framework—Hono, Fastify, Elysia, Koa, etc.—just adapt the middleware.
+:::
+
+## Installation
+
+First, install LogLayer, the wide events mixin, and Express:
+
+::: code-group
+
+```bash [npm]
+npm install loglayer @loglayer/mixin-wide-events express
+```
+
+```bash [pnpm]
+pnpm add loglayer @loglayer/mixin-wide-events express
+```
+
+```bash [yarn]
+yarn add loglayer @loglayer/mixin-wide-events express
+```
+
+```bash [bun]
+bun add loglayer @loglayer/mixin-wide-events express
+```
+
+:::
+
+## Setup
+
+### 1. Create the AsyncLocalStorage instance
+
+```typescript
+// async-local-storage.ts
+import { AsyncLocalStorage } from "async_hooks";
+import type { ILogLayer } from "loglayer";
+
+export const asyncLocalStorage = new AsyncLocalStorage<{
+  logger: ILogLayer;
+}>();
+```
+
+### 2. Create logger helper
+
+```typescript
+// logger.ts
+import { asyncLocalStorage } from "./async-local-storage.js";
+import { LogLayer, ConsoleTransport, useLogLayerMixin } from "loglayer";
+import { createWideEventMixin } from "@loglayer/mixin-wide-events";
+
+// Register the mixin globally (once at startup)
+useLogLayerMixin(createWideEventMixin({ asyncContext: asyncLocalStorage }));
+
+// Create LogLayer
+export const log = new LogLayer({
+  transport: new ConsoleTransport({ logger: console }),
+});
+
+// Helper to get the request-specific logger
+export function getLogger() {
+  return asyncLocalStorage.getStore()?.logger ?? log;
+}
+```
+
+### 3. Implement with Express
+
+```typescript
+// app.ts
+import express from "express";
+import { asyncLocalStorage, log, getLogger } from "./logger.js";
+
+const app = express();
+app.use(express.json());
+
+// Middleware: Set up async context per request
+app.use((req, res, next) => {
+  req.id = (req.headers["x-request-id"] as string) || crypto.randomUUID();
+  
+  const logger = log.child().withContext({
+    requestId: req.id,
+    method: req.method,
+    path: req.path,
+    service: "my-service",
+  });
+  
+  asyncLocalStorage.run({ logger }, next);
+});
+
+// Helper to add timing
+function addTiming(operation: string, startTime: number) {
+  getLogger().withWideEvents({
+    [`${operation}Duration`]: Date.now() - startTime,
+  });
+}
+
+// Example: Get user
+async function getUser(userId: string) {
+  const logger = getLogger();
+  const startTime = Date.now();
+  
+  logger.debug("Fetching user");
+  const user = { id: userId, name: "Alice", tier: "premium" };
+  
+  addTiming("getUser", startTime);
+  logger.withContext({ userId: user.id }).debug("User fetched");
+  
+  return user;
+}
+
+// Example: Save order
+async function saveOrder(order: { userId: string; items: string[] }) {
+  const logger = getLogger();
+  const startTime = Date.now();
+  
+  logger.withMetadata({ items: order.items }).debug("Saving order");
+  const savedOrder = { ...order, id: "order-123", createdAt: new Date() };
+  
+  addTiming("saveOrder", startTime);
+  logger.withContext({ orderId: savedOrder.id }).info("Order saved");
+  
+  return savedOrder;
+}
+
+// Route handler
+app.post("/api/orders", async (req, res) => {
+  const logger = getLogger();
+  const { userId, items } = req.body as { userId: string; items?: string[] };
+  const startTime = Date.now();
+
+  logger
+    .withMetadata({ userId, itemCount: items?.length ?? 0 })
+    .info("Creating order");
+
+  try {
+    const user = await getUser(userId);
+    logger.withWideEvents({ user: { id: user.id, tier: user.tier } });
+
+    const order = await saveOrder({ userId, items: items ?? [] });
+    logger.withWideEvents({ order: { id: order.id, itemCount: items?.length ?? 0 } });
+
+    res.status(201).json(order);
+  } catch (error) {
+    logger.withError(error as Error).error("Order failed");
+    res.status(500).json({ error: "Failed to create order" });
+  }
+
+  // Emit wide event on response finish
+  res.on("finish", () => {
+    logger.withWideEvents({
+      duration: Date.now() - startTime,
+      statusCode: res.statusCode,
+      outcome: res.statusCode >= 400 ? "error" : "ok",
+    });
+    logger.emitWideEvent({ message: "Request completed" });
+  });
+
+  res.on("error", () => {
+    logger.withWideEvents({
+      duration: Date.now() - startTime,
+      outcome: "error",
+    });
+    logger.emitWideEvent({ message: "Request failed", level: "error" });
+  });
+});
+
+app.listen(3000, () => console.log("Server running on http://localhost:3000"));
+```
+
+## Run It
+
+```bash
+curl -X POST http://localhost:3000/api/orders \
+  -H "Content-Type: application/json" \
+  -H "x-request-id: test-123" \
+  -d '{"userId": "user-1", "items": ["widget", "gadget"]}'
+```
+
+## Output
+
+The wide event accumulates all data throughout the request:
+
+```json
+{
+  "level": "info",
+  "time": "2026-05-26T03:42:57.070Z",
+  "msg": "Request completed",
+  "requestId": "test-123",
+  "method": "POST",
+  "path": "/api/orders",
+  "service": "my-service",
+  "userId": "user-1",
+  "itemCount": 2,
+  "user": { "id": "user-1", "tier": "premium" },
+  "getUserDuration": 0,
+  "saveOrderDuration": 0,
+  "order": { "id": "order-123", "itemCount": 2 },
+  "duration": 3,
+  "statusCode": 201,
+  "outcome": "ok"
+}
+```
+
+## How It Works
+
+1. **AsyncLocalStorage** holds the request-specific logger, propagating it
+   across all `await` calls within the same request
+2. **Middleware** creates a child logger with `log.child()` and stores it
+   in the async context
+3. **`withWideEvents()`** automatically initializes `_llWideEvents` on
+   first use and accumulates data
+4. **`emitWideEvent()`** outputs the accumulated data as a single log entry
+5. **`res.on("finish")`** triggers the final emission
+
+The key is using `log.child()` in the middleware. This creates an isolated
+logger for each request, so context from one request doesn't leak into
+another.
+
+## What to Include in a Wide Event
+
+A well-formed wide event includes:
+
+**Always included:**
+- `duration` - How long the operation took
+- `outcome` - `"ok"` or `"error"`
+- `statusCode` - HTTP status or error code
+
+**Request context (set via withContext):**
+- `requestId` - For correlation
+- `method`, `path` - What was requested
+- `service` - Which service generated this
+
+**Business data (accumulated via withWideEvents):**
+- What was saved/updated/deleted
+- External API responses
+- Cache hits/misses
+- Operation timing for each step
+
+## Related
+
+- [Wide Events Mixin](/mixins/wide-events)
+- [AsyncLocalStorage](/example-integrations/async-context)
+- [Basic Logging](/logging-api/basic-logging)
+- [Child Loggers](/logging-api/child-loggers)
+- [Logging Sucks](https://loggingsucks.com/) - The original article

--- a/docs/src/mixins/_partials/mixin-list.md
+++ b/docs/src/mixins/_partials/mixin-list.md
@@ -2,5 +2,6 @@
 
 | Name | Package | Description |
 |------|---------|-------------|
+| [Wide Events](/mixins/wide-events) <Badge type="tip" text="Server" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-wide-events)](https://www.npmjs.com/package/@loglayer/mixin-wide-events) | Adds wide event logging for comprehensive, self-contained log entries |
 | [Datadog Metrics (HTTP)](/mixins/datadog-http-metrics) <Badge type="tip" text="Server" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-datadog-http-metrics)](https://www.npmjs.com/package/@loglayer/mixin-datadog-http-metrics) | Adds the [`datadog-metrics`](https://github.com/dbader/node-datadog-metrics) API to LogLayer |
 | [Hot-Shots (StatsD)](/mixins/hot-shots) <Badge type="tip" text="Server" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-hot-shots)](https://www.npmjs.com/package/@loglayer/mixin-hot-shots) | Adds the [`hot-shots`](https://github.com/bdeitte/hot-shots) API to LogLayer |

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -103,10 +103,10 @@ const mixin = createWideEventMixin({
 });
 ```
 
-**Type:** `createWideEventMixin(options: WideEventMixinOptions)`
+### Configuration
 
-| Name | Type | Default | Description |
-|------|------|---------|-------------|
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
 | `asyncContext` | `AsyncLocalStorage<Record<string, any>>` | - | An async context implementation for propagating wide event data across async boundaries. |
 | `includeContext` | `boolean` | `true` | Include data from `withContext()` calls in the emitted wide event. |
 | `wideEventField` | `string` | `undefined` | Field name to nest all wide event data under. When undefined, data is flattened at root level. |
@@ -179,16 +179,14 @@ logger.clearWideEvents("user");
 
 ### `emitWideEvent(config)`
 
-**Type:** `(config: EmitWideEventConfig) => this`
+Emits the accumulated wide event as a single log entry. Returns the logger
+for chaining.
 
-| Name | Type | Default | Description |
-|------|------|---------|-------------|
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
 | `message` | `string` | - | The log message for the wide event. |
 | `level` | `LogLevelType` | `"info"` | The log level for the emission. |
 | `metadata` | `Record<string, any>` | `undefined` | Additional metadata to include in this emission. |
-
-Emits the accumulated wide event as a single log entry. Returns the logger
-for chaining.
 
 ```typescript
 logger.emitWideEvent({ message: "Order processed" });

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -103,11 +103,18 @@ const mixin = createWideEventMixin({
 });
 ```
 
-### Configuration
+## Configuration Options
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `asyncContext` | `AsyncLocalStorage<Record<string, any>>` | - | An async context implementation for propagating wide event data across async boundaries. |
+### Required Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| `asyncContext` | `AsyncLocalStorage<Record<string, any>>` | An async context implementation for propagating wide event data across async boundaries. |
+
+### Optional Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
 | `includeContext` | `boolean` | `true` | Include data from `withContext()` calls in the emitted wide event. |
 | `wideEventField` | `string` | `undefined` | Field name to nest all wide event data under. When undefined, data is flattened at root level. |
 

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -1,0 +1,345 @@
+# Wide Events Mixin <Badge type="tip" text="Server" /> <Badge type="info" text="Deno" /> <Badge type="info" text="Bun" />
+
+[![npm version](https://img.shields.io/npm/v/@loglayer/mixin-wide-events.svg)](https://www.npmjs.com/package/@loglayer/mixin-wide-events)
+
+[![Source](https://img.shields.io/badge/source-GitHub-blue)](https://github.com/loglayer/loglayer/tree/master/packages/mixins/wide-events)
+
+The Wide Events Mixin adds functionality for creating comprehensive, self-contained log entries that capture an entire operation's context and data in a single emission. This pattern is sometimes called "canonical log lines" or "wide events."
+
+For a complete Express example, see the [Event-Wide Logging guide](/guides/event-wide-logging).
+
+## Installation
+
+::: code-group
+
+```bash [npm]
+npm install @loglayer/mixin-wide-events
+```
+
+```bash [pnpm]
+pnpm add @loglayer/mixin-wide-events
+```
+
+```bash [yarn]
+yarn add @loglayer/mixin-wide-events
+```
+
+```bash [bun]
+bun add @loglayer/mixin-wide-events
+```
+
+```bash [deno]
+deno add npm:@loglayer/mixin-wide-events
+```
+
+:::
+
+## Why Wide Events?
+
+Wide events solve a common observability problem: when you have distributed systems with many log entries, it can be difficult to correlate all the data from a single operation. Wide events capture everything in one place, making it easy to:
+
+- See the complete context of an operation at a glance
+- Correlate all data without joining multiple log entries
+- Simplify log analysis and debugging
+
+For more context, see [Why Logging Sucks](https://loggingsucks.com/).
+
+## Quick Start
+
+### 1. Create the AsyncLocalStorage instance
+
+```typescript
+// async-local-storage.ts
+import { AsyncLocalStorage } from "async_hooks";
+import type { ILogLayer } from "loglayer";
+
+export const asyncLocalStorage = new AsyncLocalStorage<{
+  logger: ILogLayer;
+}>();
+```
+
+### 2. Create a helper to get the logger
+
+```typescript
+// logger.ts
+import { asyncLocalStorage } from "./async-local-storage";
+import { LogLayer, StructuredTransport, useLogLayerMixin } from "loglayer";
+import { createWideEventMixin } from "@loglayer/mixin-wide-events";
+
+// Register the mixin once
+useLogLayerMixin(createWideEventMixin({ asyncContext: asyncLocalStorage }));
+
+// Create LogLayer
+export const log = new LogLayer({
+  transport: new StructuredTransport({ logger: console }),
+});
+
+// Helper to get logger from async context
+export function getLogger() {
+  return asyncLocalStorage.getStore()?.logger ?? log;
+}
+```
+
+### 3. Use in your code
+
+```typescript
+getLogger().withWideEvents({ userId: "123" });
+await doSomething();
+getLogger().withWideEvents({ orderId: "456" });
+getLogger().emitWideEvent({ message: "Order processed" });
+```
+
+## API
+
+### `createWideEventMixin(options)`
+
+Creates a wide event mixin that can be registered with LogLayer.
+
+```typescript
+import { createWideEventMixin } from "@loglayer/mixin-wide-events";
+
+const mixin = createWideEventMixin({
+  asyncContext: new AsyncLocalStorage(),
+});
+```
+
+#### Options
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `asyncContext` | `AsyncLocalStorage<Record<string, any>>` | - | An async context implementation for propagating wide event data across async boundaries. |
+| `includeContext` | `boolean` | `true` | Include data from `withContext()` calls in the emitted wide event. |
+| `wideEventField` | `string` | `undefined` | Field name to nest all wide event data under. When undefined, data is flattened at root level. |
+
+**Type:** `WideEventMixinOptions`
+
+### `withWideEvents(data)`
+
+Accumulates data into the wide event. Call multiple times to build up the event.
+Nested objects are **deep merged** - later calls merge into existing nested objects
+rather than replacing them entirely.
+Returns the logger for chaining.
+
+```typescript
+// Simple accumulation
+logger.withWideEvents({ userId: "123" });
+await doSomething();
+logger.withWideEvents({ orderId: "456" });
+
+// Nested objects are merged:
+logger.withWideEvents({ user: { id: "123" } });
+logger.withWideEvents({ user: { name: "Alice" } });
+// Result: { user: { id: "123", name: "Alice" } }
+
+// Or chain with other methods
+log.child()
+  .withContext({ requestId: "123" })
+  .withWideEvents({ userId: "456" })
+  .info("Processing");
+```
+
+### `getWideEvents(key?)`
+
+**Type:** `(key?: string) => Record<string, any> | any`
+
+Retrieves the currently accumulated wide event data. Returns undefined if called
+outside async context or if the key doesn't exist.
+
+```typescript
+logger.withWideEvents({ userId: "123" });
+logger.withWideEvents({ orderId: "456" });
+
+// Get all accumulated data
+const data = logger.getWideEvents();
+// { userId: "123", orderId: "456" }
+
+// Get specific key
+const userId = logger.getWideEvents("userId");
+// "123"
+```
+
+### `clearWideEvents(key?)`
+
+**Type:** `(key?: string) => this`
+
+Clears the accumulated wide event data. Optionally clear only a specific key.
+Returns the logger for chaining.
+
+```typescript
+// Clear all data
+logger.withWideEvents({ first: "data" });
+logger.emitWideEvent({ message: "First" });
+logger.clearWideEvents();
+logger.withWideEvents({ second: "data" });
+logger.emitWideEvent({ message: "Second" });
+
+// Clear specific key
+logger.withWideEvents({ user: { id: "123", name: "Alice" } });
+logger.clearWideEvents("user");
+// Result: user object is removed
+```
+
+### `emitWideEvent(config)`
+
+**Type:** `(config: EmitWideEventConfig) => this`
+
+Emits the accumulated wide event as a single log entry. Returns the logger
+for chaining.
+
+```typescript
+logger.emitWideEvent({ message: "Order processed" });
+
+// Or chain with other operations
+logger
+  .withWideEvents({ statusCode: 200 })
+  .emitWideEvent({ message: "Request completed" })
+  .info("After emitting");
+```
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `message` | `string` | - | The log message for the wide event. |
+| `level` | `LogLevelType` | `"info"` | The log level for the emission. |
+| `metadata` | `Record<string, any>` | `undefined` | Additional metadata to include in this emission. |
+
+**Returns:** `this` (the logger, for chaining) |
+
+### Data Priority
+
+When multiple sources provide the same key, the following priority order applies:
+
+1. **`withContext()`** data (lowest priority)
+2. **`withWideEvents()`** data
+3. **`emitWideEvent({ metadata: {...} })`** data (highest priority)
+
+Top-level keys are overwritten by later calls. Nested objects are **deep merged**.
+
+```typescript
+// Top-level keys: later calls win
+logger.withWideEvents({ key: "first" });
+logger.withWideEvents({ key: "second" });
+// Result: key = "second"
+
+// Nested objects: merged together
+logger.withWideEvents({ user: { id: "123" } });
+logger.withWideEvents({ user: { name: "Alice" } });
+// Result: { user: { id: "123", name: "Alice" } }
+
+// Priority example
+logger.withContext({ key: "from-context" });
+logger.withWideEvents({ key: "from-wideEvents" });
+logger.emitWideEvent({ message: "test" });
+// Result: key = "from-wideEvents" (wideEvents overrides context)
+```
+
+### Interaction with `withMetadata()`
+
+`withMetadata()` and `withWideEvents()` serve different purposes:
+
+- **`withMetadata()`** - Adds metadata to an immediate log entry (not accumulated into wide events)
+- **`withWideEvents()`** - Accumulates data for the final wide event emission
+
+```typescript
+// withMetadata() logs immediately with the data
+logger.withMetadata({ userId: "123" }).info("User action");
+// Output: { msg: "User action", userId: "123" }
+
+// withWideEvents() accumulates for emitWideEvent()
+logger.withWideEvents({ orderId: "456" });
+logger.emitWideEvent({ message: "Wide event" });
+// Output: { msg: "Wide event", orderId: "456" }
+
+// They work independently and can be used together
+logger.withMetadata({ debug: true }).debug("Debug info");
+logger.withWideEvents({ businessData: "value" });
+logger.emitWideEvent({ message: "Complete" });
+// Intermediate log: { msg: "Debug info", debug: true }
+// Wide event: { msg: "Complete", businessData: "value" }
+```
+
+## Complete Example
+
+Here's a complete Express middleware example:
+
+```typescript
+// async-local-storage.ts
+import { AsyncLocalStorage } from "async_hooks";
+
+export const asyncLocalStorage = new AsyncLocalStorage<{
+  logger: import("loglayer").ILogLayer;
+}>();
+```
+
+```typescript
+// logger.ts
+import { asyncLocalStorage } from "./async-local-storage";
+import { LogLayer, StructuredTransport, useLogLayerMixin } from "loglayer";
+import { createWideEventMixin } from "@loglayer/mixin-wide-events";
+
+useLogLayerMixin(createWideEventMixin({ asyncContext: asyncLocalStorage }));
+
+export const log = new LogLayer({
+  transport: new StructuredTransport({ logger: console }),
+});
+
+export function getLogger() {
+  return asyncLocalStorage.getStore()?.logger ?? log;
+}
+```
+
+```typescript
+// app.ts
+import express from "express";
+import { asyncLocalStorage } from "./async-local-storage";
+import { log, getLogger } from "./logger";
+
+const app = express();
+
+// Set up context per request
+app.use((req, res, next) => {
+  const logger = log.child().withContext({ requestId: req.id });
+  asyncLocalStorage.run({ logger }, next);
+});
+
+// Route handler - no wrapping needed!
+app.get("/orders/:id", (req, res) => {
+  getLogger().debug("Fetching order");
+  const order = getOrder(req.params.id);
+  
+  getLogger().withWideEvents({ orderId: order.id, items: order.items.length });
+  
+  res.on("finish", () => {
+    getLogger().withWideEvents({ statusCode: res.statusCode });
+    getLogger().emitWideEvent({ message: "Request completed" });
+  });
+  
+  res.json(order);
+});
+```
+
+## Browser Compatibility
+
+The `AsyncLocalStorage` class is from Node.js and not available in browsers. For browser environments, provide your own compatible async context implementation:
+
+```typescript
+class BrowserAsyncContext<T> {
+  run(data: T, callback: () => void) {
+    this.store = data;
+    callback();
+  }
+
+  getStore(): T | undefined {
+    return this.store;
+  }
+
+  private store: T | undefined;
+}
+
+const browserContext = new BrowserAsyncContext();
+const mixin = createWideEventMixin({ asyncContext: browserContext });
+```
+
+## See Also
+
+- [Event-Wide Logging Guide](/guides/event-wide-logging) - A comprehensive guide to implementing wide event logging
+- [AsyncLocalStorage](https://nodejs.org/api/async_hooks.html#asynchooksasynclocalstorage) - Node.js documentation

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -120,6 +120,8 @@ const mixin = createWideEventMixin({
 
 ### `withWideEvents(data)`
 
+`(data: Record<string, any>) => this`
+
 Accumulates data into the wide event. Call multiple times to build up the event.
 Nested objects are **deep merged** - later calls merge into existing nested objects
 rather than replacing them entirely.
@@ -145,7 +147,7 @@ log.child()
 
 ### `getWideEvents(key?)`
 
-**Type:** `(key?: string) => Record<string, any> | any`
+`(key?: string) => Record<string, any> | any`
 
 Retrieves the currently accumulated wide event data. Returns undefined if called
 outside async context or if the key doesn't exist.
@@ -165,7 +167,7 @@ const userId = logger.getWideEvents("userId");
 
 ### `clearWideEvents(key?)`
 
-**Type:** `(key?: string) => this`
+`(key?: string) => this`
 
 Clears the accumulated wide event data. Optionally clear only a specific key.
 Returns the logger for chaining.
@@ -185,6 +187,8 @@ logger.clearWideEvents("user");
 ```
 
 ### `emitWideEvent(config)`
+
+`(config: { message: string; level?: LogLevelType; metadata?: Record<string, any> }) => this`
 
 Emits the accumulated wide event as a single log entry. Returns the logger
 for chaining.

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -113,6 +113,36 @@ const mixin = createWideEventMixin({
 
 **Type:** `WideEventMixinOptions`
 
+```typescript
+interface WideEventMixinOptions {
+  /**
+   * An async context implementation for propagating wide event data across async boundaries.
+   * @example
+   * ```typescript
+   * const asyncLocalStorage = new AsyncLocalStorage<{
+   *   logger: ILogLayer;
+   * }>();
+   * ```
+   */
+  asyncContext: AsyncLocalStorage<Record<string, any>>;
+  /**
+   * Include data from `withContext()` calls in the emitted wide event.
+   * @default true
+   */
+  includeContext?: boolean;
+  /**
+   * Field name to nest all wide event data under. When undefined, data is flattened at root level.
+   * @default undefined
+   * @example
+   * ```typescript
+   * // With wideEventField: data will be nested under 'wideEvents'
+   * // { wideEvents: { userId: "123", orderId: "456" } }
+   * ```
+   */
+  wideEventField?: string;
+}
+```
+
 ### `withWideEvents(data)`
 
 Accumulates data into the wide event. Call multiple times to build up the event.
@@ -182,6 +212,24 @@ logger.clearWideEvents("user");
 ### `emitWideEvent(config)`
 
 **Type:** `(config: EmitWideEventConfig) => this`
+
+```typescript
+interface EmitWideEventConfig {
+  /**
+   * The log message for the wide event.
+   */
+  message: string;
+  /**
+   * The log level for the emission.
+   * @default "info"
+   */
+  level?: LogLevelType;
+  /**
+   * Additional metadata to include in this emission.
+   */
+  metadata?: Record<string, any>;
+}
+```
 
 Emits the accumulated wide event as a single log entry. Returns the logger
 for chaining.

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -103,45 +103,13 @@ const mixin = createWideEventMixin({
 });
 ```
 
-#### Options
+**Type:** `createWideEventMixin(options: WideEventMixinOptions)`
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `asyncContext` | `AsyncLocalStorage<Record<string, any>>` | - | An async context implementation for propagating wide event data across async boundaries. |
 | `includeContext` | `boolean` | `true` | Include data from `withContext()` calls in the emitted wide event. |
 | `wideEventField` | `string` | `undefined` | Field name to nest all wide event data under. When undefined, data is flattened at root level. |
-
-**Type:** `WideEventMixinOptions`
-
-```typescript
-interface WideEventMixinOptions {
-  /**
-   * An async context implementation for propagating wide event data across async boundaries.
-   * @example
-   * ```typescript
-   * const asyncLocalStorage = new AsyncLocalStorage<{
-   *   logger: ILogLayer;
-   * }>();
-   * ```
-   */
-  asyncContext: AsyncLocalStorage<Record<string, any>>;
-  /**
-   * Include data from `withContext()` calls in the emitted wide event.
-   * @default true
-   */
-  includeContext?: boolean;
-  /**
-   * Field name to nest all wide event data under. When undefined, data is flattened at root level.
-   * @default undefined
-   * @example
-   * ```typescript
-   * // With wideEventField: data will be nested under 'wideEvents'
-   * // { wideEvents: { userId: "123", orderId: "456" } }
-   * ```
-   */
-  wideEventField?: string;
-}
-```
 
 ### `withWideEvents(data)`
 
@@ -213,23 +181,11 @@ logger.clearWideEvents("user");
 
 **Type:** `(config: EmitWideEventConfig) => this`
 
-```typescript
-interface EmitWideEventConfig {
-  /**
-   * The log message for the wide event.
-   */
-  message: string;
-  /**
-   * The log level for the emission.
-   * @default "info"
-   */
-  level?: LogLevelType;
-  /**
-   * Additional metadata to include in this emission.
-   */
-  metadata?: Record<string, any>;
-}
-```
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `message` | `string` | - | The log message for the wide event. |
+| `level` | `LogLevelType` | `"info"` | The log level for the emission. |
+| `metadata` | `Record<string, any>` | `undefined` | Additional metadata to include in this emission. |
 
 Emits the accumulated wide event as a single log entry. Returns the logger
 for chaining.
@@ -243,14 +199,6 @@ logger
   .emitWideEvent({ message: "Request completed" })
   .info("After emitting");
 ```
-
-| Name | Type | Default | Description |
-|------|------|---------|-------------|
-| `message` | `string` | - | The log message for the wide event. |
-| `level` | `LogLevelType` | `"info"` | The log level for the emission. |
-| `metadata` | `Record<string, any>` | `undefined` | Additional metadata to include in this emission. |
-
-**Returns:** `this` (the logger, for chaining) |
 
 ### Data Priority
 

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -327,6 +327,7 @@ Other: HTTP, Log File Rotation, OpenTelemetry
 - [Context Managers](https://loglayer.dev/context-managers/): Customize context inheritance behavior
 - [Log Level Managers](https://loglayer.dev/log-level-managers/): Customize log level behavior
 - [Mixins](https://loglayer.dev/mixins/): Extend LogLayer with custom methods
+  - [Wide Events](https://loglayer.dev/mixins/wide-events): Comprehensive, self-contained log entries
 - [ElysiaJS Integration](https://loglayer.dev/integrations/elysia): ElysiaJS plugin with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
 - [Express Integration](https://loglayer.dev/integrations/express): Express middleware with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
 - [Fastify Integration](https://loglayer.dev/integrations/fastify): Fastify integration with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -28,7 +28,9 @@ See the [Basic Logging documentation](/logging-api/basic-logging#tagged-template
   - `schema?: LogLayerPluginSchema` - Schema information for navigating the assembled data (`contextFieldName`, `metadataFieldName`, `errorFieldName`)
   - `prefix?: string` - The prefix attached via `withPrefix()`
 
-These parameters are also passed to transport `_sendToLogger` calls. See the [Creating Plugins documentation](/plugins/creating-plugins#loglayerpluginschema) for details.
+`@loglayer/mixin-wide-events`:
+
+- **New Wide Events Mixin**: Adds `withWideEvents()` and `emitWideEvent()` methods for comprehensive, self-contained log entries that capture an entire operation's context. See the [Wide Events documentation](/mixins/wide-events) and [Event-Wide Logging guide](/guides/event-wide-logging).
 
 ## May 15, 2026
 

--- a/packages/mixins/wide-events/README.md
+++ b/packages/mixins/wide-events/README.md
@@ -1,0 +1,9 @@
+# @loglayer/mixin-wide-events
+
+[![npm version](https://img.shields.io/npm/v/@loglayer/mixin-wide-events.svg)](https://www.npmjs.com/package/@loglayer/mixin-wide-events)
+[![npm downloads](https://img.shields.io/npm/dm/@loglayer/mixin-wide-events.svg)](https://www.npmjs.com/package/@loglayer/mixin-wide-events)
+[![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
+
+Adds wide event logging functionality to LogLayer for comprehensive, self-contained log entries.
+
+[Documentation](https://loglayer.dev/mixins/wide-events) | [API Reference](https://loglayer.dev/mixins/wide-events)

--- a/packages/mixins/wide-events/README.md
+++ b/packages/mixins/wide-events/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@loglayer/mixin-wide-events.svg)](https://www.npmjs.com/package/@loglayer/mixin-wide-events)
 [![npm downloads](https://img.shields.io/npm/dm/@loglayer/mixin-wide-events.svg)](https://www.npmjs.com/package/@loglayer/mixin-wide-events)
-[![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
 
 Adds wide event logging functionality to LogLayer for comprehensive, self-contained log entries.
 

--- a/packages/mixins/wide-events/package.json
+++ b/packages/mixins/wide-events/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@loglayer/mixin-wide-events",
+  "description": "Adds wide event logging functionality to LogLayer for comprehensive, self-contained log entries.",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "require": {
+      "types": "./dist/index.d.cts",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "types": "./dist/index.d.mts",
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/loglayer/loglayer.git",
+    "directory": "packages/mixins/wide-events"
+  },
+  "author": "Theo Gravity <theo@suteki.nu>",
+  "keywords": [
+    "logging",
+    "log",
+    "loglayer",
+    "observability",
+    "wide-events",
+    "canonical-log-lines"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.ts",
+    "test": "vitest --run",
+    "clean": "rm -rf .turbo node_modules dist",
+    "lint": "biome check --no-errors-on-unmatched --write --unsafe src",
+    "lint:staged": "biome check --no-errors-on-unmatched --write --unsafe --staged src",
+    "verify-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@internal/tsconfig": "workspace:*",
+    "@loglayer/shared": "workspace:*",
+    "@types/node": "25.2.3",
+    "loglayer": "workspace:*",
+    "tsdown": "0.20.3",
+    "typescript": "5.9.3",
+    "vitest": "4.0.18"
+  },
+  "peerDependencies": {},
+  "bugs": "https://github.com/loglayer/loglayer/issues",
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://loglayer.dev",
+  "packageManager": "pnpm@10.20.0"
+}

--- a/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Type tests for @loglayer/mixin-wide-events
+ *
+ * These tests verify that TypeScript correctly infers types when using
+ * ILogLayer<LogLayer> interface with the wide-events mixin.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ILogLayer } from "loglayer";
+import { LogLayer, useLogLayerMixin } from "loglayer";
+import { describe, expectTypeOf, it } from "vitest";
+import { createWideEventMixin } from "../index.js";
+
+describe("Type Tests", () => {
+  // Setup mixin once for all tests
+  const asyncContext = new AsyncLocalStorage<Record<string, any>>();
+  const wideEventsMixin = createWideEventMixin({ asyncContext });
+  useLogLayerMixin(wideEventsMixin);
+
+  it("should preserve type when using ILogLayer interface", () => {
+    const logger: ILogLayer = new LogLayer({ transport: {} as any });
+
+    // withWideEvents should return the logger type
+    const result1 = logger.withWideEvents({ userId: "123" });
+    expectTypeOf(result1).toMatchTypeOf<ILogLayer>();
+
+    // getWideEvents should return data
+    const result2 = logger.getWideEvents();
+    expectTypeOf(result2).toMatchTypeOf<Record<string, any> | any>();
+
+    // clearWideEvents should return the logger type
+    const result3 = logger.clearWideEvents();
+    expectTypeOf(result3).toMatchTypeOf<ILogLayer>();
+
+    // emitWideEvent should return the logger type
+    const result4 = logger.emitWideEvent({ message: "test" });
+    expectTypeOf(result4).toMatchTypeOf<ILogLayer>();
+  });
+
+  it("should allow method chaining", () => {
+    const logger: ILogLayer = new LogLayer({ transport: {} as any });
+
+    // All methods should return the same type for chaining
+    const result = logger
+      .withWideEvents({ userId: "123" })
+      .withWideEvents({ orderId: "456" })
+      .withContext({ requestStart: Date.now() })
+      .clearWideEvents()
+      .withWideEvents({ newRequest: "req-789" })
+      .emitWideEvent({ message: "New request completed" });
+
+    expectTypeOf(result).toMatchTypeOf<ILogLayer>();
+  });
+
+  it("should preserve LogLayer type", () => {
+    const logger = new LogLayer({ transport: {} as any });
+
+    // All methods should work on concrete LogLayer
+    logger.withWideEvents({ userId: "123" });
+    logger.getWideEvents();
+    logger.clearWideEvents();
+    logger.emitWideEvent({ message: "test" });
+  });
+
+  it("should allow type narrowing in functions", () => {
+    function processWithContext(logger: ILogLayer) {
+      logger.withWideEvents({ processing: true });
+      logger.getWideEvents();
+      logger.clearWideEvents();
+      logger.emitWideEvent({ message: "processed" });
+      logger.info("standard log call");
+      logger.withContext({ context: "data" });
+      return logger;
+    }
+
+    const logger = new LogLayer({ transport: {} as any });
+    const result = processWithContext(logger);
+    expectTypeOf(result).toMatchTypeOf<ILogLayer>();
+  });
+
+  it("should accept correct emitWideEvent config", () => {
+    const logger: ILogLayer = new LogLayer({ transport: {} as any });
+
+    // All config options should be valid
+    logger.emitWideEvent({ message: "msg" });
+    logger.emitWideEvent({ message: "msg", level: "error" });
+    logger.emitWideEvent({ message: "msg", metadata: { extra: "data" } });
+    logger.emitWideEvent({
+      message: "msg",
+      level: "warn",
+      metadata: { code: 123 },
+    });
+  });
+});

--- a/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
@@ -12,9 +12,9 @@ import { describe, expectTypeOf, it } from "vitest";
 import { createWideEventMixin } from "../index.js";
 
 describe("Type Tests", () => {
-  // Setup mixin once for all tests
-  const asyncContext = new AsyncLocalStorage<Record<string, any>>();
-  const wideEventsMixin = createWideEventMixin({ asyncContext });
+  // Setup mixin once for all tests (matching docs pattern)
+  const asyncLocalStorage = new AsyncLocalStorage<{ logger: ILogLayer }>();
+  const wideEventsMixin = createWideEventMixin({ asyncContext: asyncLocalStorage });
   useLogLayerMixin(wideEventsMixin);
 
   it("should preserve type when using ILogLayer interface", () => {

--- a/packages/mixins/wide-events/src/__tests__/wide-event.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/wide-event.test.ts
@@ -1,0 +1,484 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { BlankTransport, LogLayer, useLogLayerMixin } from "loglayer";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createWideEventMixin } from "../index.js";
+
+describe("WideEventMixin", () => {
+  let asyncContext: AsyncLocalStorage<Record<string, any>>;
+  let log: LogLayer;
+  let emittedLogs: any[];
+
+  beforeEach(() => {
+    asyncContext = new AsyncLocalStorage();
+    emittedLogs = [];
+
+    const transport = new BlankTransport({
+      shipToLogger: (params) => {
+        // Capture just the flat metadata (what would be logged as data fields)
+        emittedLogs.push({
+          level: params.logLevel,
+          messages: params.messages,
+          metadata: params.metadata,
+          context: params.context,
+        });
+        return params.messages;
+      },
+    });
+
+    const mixin = createWideEventMixin({ asyncContext });
+    useLogLayerMixin(mixin);
+
+    log = new LogLayer({
+      transport,
+    });
+  });
+
+  it("should accumulate wide event data via withWideEvents", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ userId: "123" });
+      logger.withWideEvents({ orderId: "456" });
+
+      const store = asyncContext.getStore();
+      expect(store?._llWideEvents).toEqual({ userId: "123", orderId: "456" });
+    });
+  });
+
+  it("should silently ignore withWideEvents when not in async context", () => {
+    const logger = log.child();
+    const result = logger.withWideEvents({ test: "value" });
+    expect(result).toBe(logger);
+  });
+
+  it("should emit wide event with accumulated data", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ userId: "123" });
+      logger.withWideEvents({ orderId: "456" });
+      logger.emitWideEvent({ message: "Order processed" });
+    });
+
+    expect(emittedLogs).toHaveLength(1);
+    expect(emittedLogs[0].messages).toContain("Order processed");
+    expect(emittedLogs[0].metadata).toEqual({
+      userId: "123",
+      orderId: "456",
+    });
+  });
+
+  it("should include context in emitted wide event by default", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child().withContext({ requestId: "req-1" });
+      logger.withWideEvents({ userId: "123" });
+      logger.emitWideEvent({ message: "Request completed" });
+    });
+
+    expect(emittedLogs[0].context).toEqual({
+      requestId: "req-1",
+    });
+    expect(emittedLogs[0].metadata).toEqual({
+      userId: "123",
+    });
+  });
+
+  it("should exclude context when includeContext is false", () => {
+    const ctx = new AsyncLocalStorage();
+    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx, includeContext: false }));
+    const l = new LogLayer({
+      transport: new BlankTransport({
+        shipToLogger: (p) => {
+          emittedLogs.push({ metadata: p.metadata, context: p.context });
+          return p.messages;
+        },
+      }),
+    });
+
+    ctx.run({}, () => {
+      const logger = l.child().withContext({ requestId: "req-1" });
+      logger.withWideEvents({ userId: "123" });
+      logger.emitWideEvent({ message: "Test" });
+    });
+
+    // Metadata should NOT include context data when includeContext is false
+    // Note: params.context still contains the logger's context (this is separate)
+    expect(emittedLogs[0].metadata).toEqual({ userId: "123" });
+    expect(emittedLogs[0].metadata.requestId).toBeUndefined();
+  });
+
+  it("should nest wide event data under wideEventField when configured", () => {
+    const ctx = new AsyncLocalStorage();
+    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx, wideEventField: "event" }));
+    const l = new LogLayer({
+      transport: new BlankTransport({
+        shipToLogger: (p) => {
+          emittedLogs.push({ metadata: p.metadata, context: p.context });
+          return p.messages;
+        },
+      }),
+    });
+
+    ctx.run({}, () => {
+      const logger = l.child();
+      logger.withContext({ requestId: "req-1" });
+      logger.withWideEvents({ userId: "123" });
+      logger.emitWideEvent({ message: "Test" });
+    });
+
+    // wideEventField should wrap the wideEvents data
+    expect(emittedLogs[0].metadata).toEqual({
+      event: { userId: "123" },
+    });
+    // Context should still be separate
+    expect(emittedLogs[0].context).toEqual({ requestId: "req-1" });
+  });
+
+  it("should allow context and wideEvents to be flattened together", () => {
+    const ctx = new AsyncLocalStorage();
+    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx }));
+    const l = new LogLayer({
+      transport: new BlankTransport({
+        shipToLogger: (p) => {
+          emittedLogs.push({ metadata: p.metadata, context: p.context });
+          return p.messages;
+        },
+      }),
+    });
+
+    ctx.run({}, () => {
+      const logger = l.child();
+      logger.withContext({ contextKey: "from-context" });
+      logger.withWideEvents({ wideEventsKey: "from-wideEvents" });
+      logger.emitWideEvent({ message: "Test" });
+    });
+
+    // Both context and wideEvents should be included
+    expect(emittedLogs[0].context).toEqual({ contextKey: "from-context" });
+    expect(emittedLogs[0].metadata).toEqual({ wideEventsKey: "from-wideEvents" });
+  });
+
+  it("should prioritize withWideEvents over withContext for same key", () => {
+    const ctx = new AsyncLocalStorage();
+    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx }));
+    const l = new LogLayer({
+      transport: new BlankTransport({
+        shipToLogger: (p) => {
+          emittedLogs.push({ metadata: p.metadata, context: p.context });
+          return p.messages;
+        },
+      }),
+    });
+
+    ctx.run({}, () => {
+      const logger = l.child();
+      logger.withContext({ key: "from-context" });
+      logger.withWideEvents({ key: "from-wideEvents" });
+      logger.emitWideEvent({ message: "Test" });
+    });
+
+    // Context has its value, but wideEvents should override in metadata
+    expect(emittedLogs[0].context).toEqual({ key: "from-context" });
+    expect(emittedLogs[0].metadata).toEqual({ key: "from-wideEvents" });
+  });
+
+  it("should prioritize emit metadata over withWideEvents for same key", () => {
+    const ctx = new AsyncLocalStorage();
+    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx }));
+    const l = new LogLayer({
+      transport: new BlankTransport({
+        shipToLogger: (p) => {
+          emittedLogs.push({ metadata: p.metadata });
+          return p.messages;
+        },
+      }),
+    });
+
+    ctx.run({}, () => {
+      const logger = l.child();
+      logger.withWideEvents({ key: "from-wideEvents" });
+      logger.emitWideEvent({ message: "Test", metadata: { key: "from-emit" } });
+    });
+
+    // Emit metadata should override wideEvents
+    expect(emittedLogs[0].metadata).toEqual({ key: "from-emit" });
+  });
+
+  it("should allow withMetadata and withWideEvents to work independently", () => {
+    const ctx = new AsyncLocalStorage();
+    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx }));
+    const l = new LogLayer({
+      transport: new BlankTransport({
+        shipToLogger: (p) => {
+          emittedLogs.push({ messages: p.messages, metadata: p.metadata });
+          return p.messages;
+        },
+      }),
+    });
+
+    ctx.run({}, () => {
+      const logger = l.child();
+
+      // withMetadata() creates immediate log
+      logger.withMetadata({ immediate: "yes" }).info("Immediate");
+
+      // withWideEvents() accumulates
+      logger.withWideEvents({ accumulated: "yes" });
+
+      // Another withMetadata()
+      logger.withMetadata({ alsoImmediate: "yes" }).warn("Another");
+
+      // withWideEvents() accumulates more
+      logger.withWideEvents({ more: "yes" });
+
+      // emitWideEvent outputs only wideEvents data (not withMetadata data)
+      logger.emitWideEvent({ message: "Wide event" });
+    });
+
+    // Should have 3 log entries: 2 immediate + 1 wide event
+    expect(emittedLogs).toHaveLength(3);
+
+    // First log (immediate withMetadata)
+    expect(emittedLogs[0].messages).toContain("Immediate");
+    expect(emittedLogs[0].metadata).toEqual({ immediate: "yes" });
+
+    // Second log (immediate withMetadata)
+    expect(emittedLogs[1].messages).toContain("Another");
+    expect(emittedLogs[1].metadata).toEqual({ alsoImmediate: "yes" });
+
+    // Third log (wide event - has only wideEvents data, not withMetadata data)
+    expect(emittedLogs[2].messages).toContain("Wide event");
+    expect(emittedLogs[2].metadata).toEqual({ accumulated: "yes", more: "yes" });
+  });
+
+  it("should support custom log level in emitWideEvent", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ data: "test" });
+      logger.emitWideEvent({ message: "Error occurred", level: "error" });
+    });
+
+    expect(emittedLogs).toHaveLength(1);
+    expect(emittedLogs[0].level).toBe("error");
+  });
+
+  it("should return logger for chaining", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      const result = logger.withWideEvents({ key: "value" });
+      expect(result).toBe(logger);
+    });
+  });
+
+  it("should return logger for emitWideEvent chaining", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      const result = logger.emitWideEvent({ message: "test" });
+      expect(result).toBe(logger);
+    });
+  });
+
+  it("should handle multiple emissions without clearing", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ initial: "data" });
+      logger.emitWideEvent({ message: "First" });
+      logger.emitWideEvent({ message: "Second" });
+    });
+
+    expect(emittedLogs).toHaveLength(2);
+    expect(emittedLogs[0].messages).toContain("First");
+    expect(emittedLogs[1].messages).toContain("Second");
+  });
+
+  it("should work with async operations", async () => {
+    await asyncContext.run({}, async () => {
+      const logger = log.child();
+      logger.withWideEvents({ step: 1 });
+
+      await Promise.resolve();
+      logger.withWideEvents({ step: 2 });
+
+      await Promise.resolve();
+      logger.emitWideEvent({ message: "Async complete" });
+    });
+
+    expect(emittedLogs[0].metadata).toEqual({
+      step: 2,
+    });
+  });
+
+  it("should not affect normal logs with wide event data", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ wideEventData: "should not appear" });
+      logger.info("Normal log");
+    });
+
+    expect(emittedLogs).toHaveLength(1);
+    expect(emittedLogs[0].messages).toContain("Normal log");
+    // Normal logs without emitWideEvent should not have the wideEvents metadata
+    expect(emittedLogs[0].metadata).toBeNull();
+  });
+
+  it("should work on child loggers", () => {
+    asyncContext.run({}, () => {
+      const parent = log.child();
+      const child = parent.child();
+      child.withWideEvents({ fromChild: "yes" });
+      child.emitWideEvent({ message: "Child event" });
+    });
+
+    expect(emittedLogs[0].metadata).toEqual({ fromChild: "yes" });
+  });
+
+  it("should deep merge nested objects", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ user: { id: "123" } });
+      logger.withWideEvents({ user: { name: "Alice" } });
+      logger.emitWideEvent({ message: "Test" });
+    });
+
+    // Both nested properties should be present
+    expect(emittedLogs[0].metadata).toEqual({
+      user: { id: "123", name: "Alice" },
+    });
+  });
+
+  it("should overwrite top-level keys but merge nested", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ user: { id: "123" }, count: 1 });
+      logger.withWideEvents({ user: { name: "Alice" }, count: 2 });
+      logger.emitWideEvent({ message: "Test" });
+    });
+
+    // count: 2 (overwritten), user: { id: "123", name: "Alice" } (merged)
+    expect(emittedLogs[0].metadata).toEqual({
+      user: { id: "123", name: "Alice" },
+      count: 2,
+    });
+  });
+
+  it("should get all wide event data with getWideEvents", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ userId: "123" });
+      logger.withWideEvents({ orderId: "456" });
+
+      const data = logger.getWideEvents();
+      expect(data).toEqual({ userId: "123", orderId: "456" });
+    });
+  });
+
+  it("should get specific key with getWideEvents(key)", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ userId: "123" });
+      logger.withWideEvents({ orderId: "456" });
+
+      const userId = logger.getWideEvents("userId");
+      expect(userId).toBe("123");
+
+      const orderId = logger.getWideEvents("orderId");
+      expect(orderId).toBe("456");
+
+      const nonExistent = logger.getWideEvents("nonexistent");
+      expect(nonExistent).toBeUndefined();
+    });
+  });
+
+  it("should return empty object from getWideEvents when no data", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      const data = logger.getWideEvents();
+      expect(data).toEqual({});
+    });
+  });
+
+  it("should return undefined for getWideEvents when outside async context", () => {
+    const logger = log.child();
+    const data = logger.getWideEvents();
+    expect(data).toEqual({});
+
+    const key = logger.getWideEvents("userId");
+    expect(key).toBeUndefined();
+  });
+
+  it("should clear all wide event data with clearWideEvents", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ userId: "123" });
+      logger.withWideEvents({ orderId: "456" });
+
+      const before = logger.getWideEvents();
+      expect(before).toEqual({ userId: "123", orderId: "456" });
+
+      logger.clearWideEvents();
+
+      const after = logger.getWideEvents();
+      expect(after).toEqual({});
+    });
+  });
+
+  it("should clear specific key with clearWideEvents(key)", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      logger.withWideEvents({ userId: "123", orderId: "456" });
+
+      const before = logger.getWideEvents();
+      expect(before).toEqual({ userId: "123", orderId: "456" });
+
+      logger.clearWideEvents("userId");
+
+      const after = logger.getWideEvents();
+      expect(after).toEqual({ orderId: "456" });
+    });
+  });
+
+  it("should return logger for clearWideEvents chaining", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      const result = logger.clearWideEvents();
+      expect(result).toBe(logger);
+    });
+  });
+
+  it("should not merge dangerous prototype keys", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      // Simulate malicious data with dangerous prototype keys
+      const maliciousData: Record<string, any> = { userId: "123" };
+      maliciousData["__proto__"] = { admin: true };
+      maliciousData["constructor"] = { prototype: {} };
+      maliciousData["prototype"] = { evil: true };
+
+      logger.withWideEvents(maliciousData);
+
+      const data = logger.getWideEvents();
+      // Should only contain userId, not dangerous keys
+      expect(data).toEqual({ userId: "123" });
+      expect(Object.keys(data)).toEqual(["userId"]);
+    });
+  });
+
+  it("should handle circular references gracefully", () => {
+    asyncContext.run({}, () => {
+      const logger = log.child();
+      // Create objects with circular reference
+      const objA: Record<string, any> = { name: "A" };
+      const objB: Record<string, any> = { name: "B" };
+      objA.ref = objB;
+      objB.ref = objA; // circular!
+
+      // Should not throw or hang - that's the key test
+      logger.withWideEvents({ first: objA });
+
+      const data = logger.getWideEvents();
+      // Structure is preserved, circular ref is detected
+      expect(data.first.name).toBe("A");
+      expect(data.first.ref.name).toBe("B");
+      // Circular reference is marked (not followed infinitely)
+      expect(data.first.ref.ref).toBeDefined();
+    });
+  });
+});

--- a/packages/mixins/wide-events/src/index.ts
+++ b/packages/mixins/wide-events/src/index.ts
@@ -1,0 +1,7 @@
+export { createWideEventMixin } from "./mixin.js";
+export type {
+  EmitWideEventConfig,
+  IWideEventMixin,
+  WideEventMixinOptions,
+} from "./types.js";
+import "./types.js"; // Import types to ensure declarations are processed

--- a/packages/mixins/wide-events/src/mixin.ts
+++ b/packages/mixins/wide-events/src/mixin.ts
@@ -1,0 +1,258 @@
+import {
+  type LogLayer,
+  type LogLayerMixin,
+  LogLayerMixinAugmentType,
+  type LogLayerMixinRegistration,
+  type LogLayerPlugin,
+} from "loglayer";
+import type { EmitWideEventConfig, WideEventMixinOptions } from "./types.js";
+
+/**
+ * Creates a LogLayer mixin that adds wide event logging functionality.
+ *
+ * Wide events are comprehensive, self-contained log entries that capture an entire
+ * operation's context and data in a single emission. This pattern helps with
+ * observability by ensuring all relevant data is available in one log entry.
+ *
+ * @param options - Configuration options
+ * @param options.asyncContext - An async context implementation for propagating
+ *   wide event data across async boundaries. For Node.js, use `new AsyncLocalStorage()`
+ *   from `async_hooks`. For browser environments, provide your own compatible implementation.
+ * @param options.includeContext - Whether to include withContext() data in emitted wide events (default: true)
+
+ *
+ * @returns A LogLayer mixin registration object
+ *
+ * @example
+ * ```typescript
+ * import { AsyncLocalStorage } from "async_hooks";
+ * import { LogLayer, StructuredTransport } from "loglayer";
+ * import { createWideEventMixin } from "@loglayer/mixin-wide-events";
+ *
+ * const wideEventMixin = createWideEventMixin({
+ *   asyncContext: new AsyncLocalStorage(),
+ * });
+ *
+ * const log = new LogLayer({
+ *   transport: new StructuredTransport({ logger: console }),
+ *   mixins: [wideEventMixin],
+ * });
+ *
+ * // Create a child logger for the request
+ * const logger = log.child().withContext({ requestId: "123" });
+ *
+ * // Accumulate data throughout the request
+ * logger.withWideEvents({ userId: "456" });
+ * await doSomething();
+ * logger.withWideEvents({ orderId: "789" });
+ *
+ * // Emit the wide event
+ * logger.emitWideEvent({ message: "Request completed" });
+ * ```
+ */
+export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMixinRegistration {
+  // Store the async context for use in methods
+  const asyncContext = options.asyncContext;
+  const includeContext = options.includeContext ?? true;
+  const wideEventField = options.wideEventField;
+
+  // Generate unique plugin ID to avoid conflicts
+  const pluginId = `@loglayer/wide-events-context-tracker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  /**
+   * Context tracker plugin - stores context in async storage
+   * for inclusion in wide events (only if includeContext is true)
+   */
+  const contextTrackerPlugin: LogLayerPlugin = {
+    id: pluginId,
+    onBeforeDataOut: (params) => {
+      if (!includeContext) {
+        return params;
+      }
+
+      const store = asyncContext.getStore();
+      if (store && params.context && Object.keys(params.context).length > 0) {
+        if (!store._llContext) {
+          store._llContext = {};
+        }
+        Object.assign(store._llContext, params.context);
+      }
+      return params;
+    },
+  };
+
+  /**
+   * Deep merge utility - merges source into target recursively for nested objects.
+   * Filters out dangerous keys to prevent prototype pollution attacks.
+   * Uses WeakRef to detect circular references.
+   */
+  function deepMerge(
+    target: Record<string, any>,
+    source: Record<string, any>,
+    visited: WeakSet<object> = new WeakSet(),
+  ): Record<string, any> {
+    const result = { ...target };
+
+    for (const key of Object.keys(source)) {
+      // Skip dangerous prototype keys to prevent pollution attacks
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        continue;
+      }
+
+      const sourceValue = source[key];
+      const targetValue = result[key];
+
+      // If both values are plain objects, merge recursively
+      if (
+        sourceValue !== null &&
+        typeof sourceValue === "object" &&
+        !Array.isArray(sourceValue) &&
+        targetValue !== null &&
+        typeof targetValue === "object" &&
+        !Array.isArray(targetValue)
+      ) {
+        // Detect circular reference - skip if already visited
+        if (visited.has(sourceValue)) {
+          continue;
+        }
+        visited.add(sourceValue);
+        result[key] = deepMerge(targetValue, sourceValue, visited);
+      } else {
+        // Otherwise, overwrite (source wins)
+        result[key] = sourceValue;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Implementation for withWideEvents
+   */
+  function withWideEventsImpl(data: Record<string, any>, self: any): any {
+    const store = asyncContext.getStore();
+    if (store) {
+      if (!store._llWideEvents) {
+        store._llWideEvents = {};
+      }
+      store._llWideEvents = deepMerge(store._llWideEvents, data);
+    }
+    return self;
+  }
+
+  /**
+   * Implementation for getWideEvents
+   */
+  function getWideEventsImpl(key?: string, _self?: any): Record<string, any> | any {
+    const store = asyncContext.getStore();
+    const data = store?._llWideEvents;
+
+    if (!data) {
+      return key ? undefined : {};
+    }
+
+    if (key !== undefined) {
+      return data[key];
+    }
+
+    // Return a copy to prevent external mutation
+    return { ...data };
+  }
+
+  /**
+   * Implementation for clearWideEvents
+   */
+  function clearWideEventsImpl(key: string | undefined, self: any): any {
+    const store = asyncContext.getStore();
+    if (store?._llWideEvents) {
+      if (key !== undefined) {
+        delete store._llWideEvents[key];
+      } else {
+        store._llWideEvents = {};
+      }
+    }
+    return self;
+  }
+
+  /**
+   * Implementation for emitWideEvent
+   */
+  function emitWideEventImpl(config: EmitWideEventConfig, self: any): any {
+    const store = asyncContext.getStore();
+
+    // Build wide event data with priority order (later = higher priority)
+    // Priority: context < wideEvents < emit metadata
+    const wideEventData: Record<string, any> = {};
+
+    // Include context data first (lowest priority)
+    if (includeContext && store?._llContext) {
+      Object.assign(wideEventData, store._llContext);
+    }
+
+    // Include wideEvents data next (overrides context)
+    if (store?._llWideEvents) {
+      Object.assign(wideEventData, store._llWideEvents);
+    }
+
+    // Include emit config metadata last (highest priority, can override anything)
+    if (config.metadata) {
+      Object.assign(wideEventData, config.metadata);
+    }
+
+    // Determine log level
+    const level = config.level ?? "info";
+
+    // Wrap in field if configured, otherwise use flat
+    const metadataToEmit = wideEventField ? { [wideEventField]: wideEventData } : wideEventData;
+
+    // Emit the wide event with metadata
+    self.withMetadata(metadataToEmit)[level](config.message);
+
+    return self;
+  }
+
+  /**
+   * Mixin for real LogLayer instances
+   */
+  const wideEventMixin: LogLayerMixin = {
+    augmentationType: LogLayerMixinAugmentType.LogLayer,
+    augment: (prototype: any) => {
+      prototype.withWideEvents = function (this: LogLayer, data: Record<string, any>) {
+        return withWideEventsImpl(data, this);
+      };
+
+      prototype.getWideEvents = function (this: LogLayer, key?: string) {
+        return getWideEventsImpl(key, this);
+      };
+
+      prototype.clearWideEvents = function (this: LogLayer, key?: string) {
+        return clearWideEventsImpl(key, this);
+      };
+
+      prototype.emitWideEvent = function (this: LogLayer, config: EmitWideEventConfig) {
+        return emitWideEventImpl(config, this);
+      };
+    },
+    augmentMock: (prototype: any) => {
+      prototype.withWideEvents = function (this: any, data: Record<string, any>) {
+        return withWideEventsImpl(data, this);
+      };
+
+      prototype.getWideEvents = function (this: any, key?: string) {
+        return getWideEventsImpl(key, this);
+      };
+
+      prototype.clearWideEvents = function (this: any, key?: string) {
+        return clearWideEventsImpl(key, this);
+      };
+
+      prototype.emitWideEvent = function (this: any, config: EmitWideEventConfig) {
+        return emitWideEventImpl(config, this);
+      };
+    },
+  };
+
+  return {
+    mixinsToAdd: [wideEventMixin],
+    pluginsToAdd: [contextTrackerPlugin],
+  };
+}

--- a/packages/mixins/wide-events/src/types.ts
+++ b/packages/mixins/wide-events/src/types.ts
@@ -1,0 +1,169 @@
+import type { AsyncLocalStorage } from "node:async_hooks";
+import type { LogLevelType } from "loglayer";
+
+/**
+ * Configuration options for creating a wide event mixin.
+ */
+export interface WideEventMixinOptions {
+  /**
+   * An async context implementation for propagating wide event data across async boundaries.
+   *
+   * For Node.js, use `new AsyncLocalStorage()` from `async_hooks`.
+   * For browser environments, provide your own compatible implementation.
+   */
+  asyncContext: AsyncLocalStorage<Record<string, any>>;
+
+  /**
+   * Optional: Include data from withContext() calls in the emitted wide event.
+   * When true, context data accumulated via withContext() will be included.
+   * @default true
+   */
+  includeContext?: boolean;
+
+  /**
+   * Optional: Field name to nest all wide event data under.
+   * When set, the wide event data will be wrapped in an object with this key.
+   * When undefined (default), wide event data is flattened at the root level.
+   * @default undefined
+   * @example
+   * // With wideEventField: "event"
+   * { "event": { "userId": "123", "orderId": "456" }, "msg": "done" }
+   * // Without wideEventField (default)
+   * { "userId": "123", "orderId": "456", "msg": "done" }
+   */
+  wideEventField?: string;
+}
+
+/**
+ * Configuration for emitting a wide event.
+ */
+export interface EmitWideEventConfig {
+  /**
+   * The log message for the wide event.
+   */
+  message: string;
+
+  /**
+   * Optional: Log level (defaults to "info").
+   */
+  level?: LogLevelType;
+
+  /**
+   * Optional: Additional metadata to include in this specific emission.
+   * This is merged with the accumulated wide event data.
+   */
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Interface for wide event mixin functionality.
+ */
+export interface IWideEventMixin {
+  /**
+   * Accumulates data into the wide event.
+   * Can be called multiple times to build up the event.
+   * Nested objects are deep merged rather than replaced entirely.
+   *
+   * @param data - Key-value pairs to add to the wide event
+   * @returns This logger instance for chaining
+   *
+   * @example
+   * ```typescript
+   * // Setup context boundary once (e.g., in middleware)
+   * asyncContext.run({}, () => {});
+   *
+   * // Use anywhere in async chain - no wrapping needed!
+   * logger.withWideEvents({ userId: "123" });
+   * await processOrder();
+   * logger.withWideEvents({ orderId: "456" });
+   * ```
+   */
+  withWideEvents(data: Record<string, any>): this;
+
+  /**
+   * Retrieves the currently accumulated wide event data.
+   * Returns undefined if called outside async context or if no data has been accumulated.
+   *
+   * @param key - Optional: Retrieve a specific key from the accumulated data
+   * @returns The accumulated data, a specific key's value, or undefined
+   *
+   * @example
+   * ```typescript
+   * logger.withWideEvents({ userId: "123" });
+   * logger.withWideEvents({ orderId: "456" });
+   *
+   * // Get all accumulated data
+   * const data = logger.getWideEvents();
+   * // { userId: "123", orderId: "456" }
+   *
+   * // Get specific key
+   * const userId = logger.getWideEvents("userId");
+   * // "123"
+   * ```
+   */
+  getWideEvents(key?: string): Record<string, any> | any;
+
+  /**
+   * Clears the accumulated wide event data.
+   * Useful when starting a new operation within the same async context.
+   *
+   * @param key - Optional: Clear only a specific key instead of all data
+   * @returns This logger instance for chaining
+   *
+   * @example
+   * ```typescript
+   * // Clear all wide event data
+   * logger.withWideEvents({ first: "data" });
+   * logger.emitWideEvent({ message: "First event" });
+   * logger.clearWideEvents();
+   * logger.withWideEvents({ second: "data" });
+   * logger.emitWideEvent({ message: "Second event" });
+   *
+   * // Clear specific key
+   * logger.withWideEvents({ user: { id: "123", name: "Alice" } });
+   * logger.clearWideEvents("user");
+   * // Result: user object is removed
+   * ```
+   */
+  clearWideEvents(key?: string): this;
+
+  /**
+   * Emits the accumulated wide event as a single log entry.
+   * Reads accumulated data from AsyncLocalStorage, merges with current context,
+   * and logs at the specified level.
+   *
+   * @param config - Configuration for the wide event emission
+   * @returns This logger instance for chaining
+   *
+   * @example
+   * ```typescript
+   * // Emit as info log
+   * logger.emitWideEvent({ message: "Order processed" });
+   *
+   * // Emit as error with additional metadata
+   * logger.emitWideEvent({
+   *   message: "Order failed",
+   *   level: "error",
+   *   metadata: { reason: "payment_declined" }
+   * });
+   * ```
+   */
+  emitWideEvent(config: EmitWideEventConfig): this;
+}
+
+// Module augmentation for ILogLayer and ILogBuilder
+declare module "loglayer" {
+  interface LogLayer extends IWideEventMixin {}
+
+  interface MockLogLayer extends IWideEventMixin {}
+
+  interface LogBuilder extends IWideEventMixin {}
+
+  interface MockLogBuilder extends IWideEventMixin {}
+}
+
+declare module "@loglayer/shared" {
+  interface ILogLayer<This> extends IWideEventMixin {}
+
+  interface ILogBuilder<This> extends IWideEventMixin {}
+}

--- a/packages/mixins/wide-events/tsconfig.json
+++ b/packages/mixins/wide-events/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@internal/tsconfig/tsconfig.json",
+  "include": ["./src/**/*"]
+}

--- a/packages/mixins/wide-events/tsdown.config.ts
+++ b/packages/mixins/wide-events/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "./src/index.ts",
+  dts: true,
+  splitting: false,
+  clean: true,
+  format: ["esm", "cjs"],
+});

--- a/packages/mixins/wide-events/turbo.json
+++ b/packages/mixins/wide-events/turbo.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "clean": {},
+    "test": {
+      "inputs": [
+        "*.ts",
+        "src/**",
+        "*.json"
+      ]
+    },
+    "lint": {
+      "inputs": [
+        "*.ts",
+        "src/**",
+        "*.json"
+      ]
+    },
+    "verify-types": {
+      "inputs": [
+        "*.ts",
+        "src/**",
+        "*.json"
+      ]
+    },
+    "build": {
+      "dependsOn": [
+        "@internal/tsconfig#build",
+        "loglayer#build"
+      ],
+      "inputs": [
+        "src/**",
+        "*.json"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,30 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(less@4.4.2)(tsx@4.21.0)
 
+  packages/mixins/wide-events:
+    devDependencies:
+      '@internal/tsconfig':
+        specifier: workspace:*
+        version: link:../../core/tsconfig
+      '@loglayer/shared':
+        specifier: workspace:*
+        version: link:../../core/shared
+      '@types/node':
+        specifier: 25.2.3
+        version: 25.2.3
+      loglayer:
+        specifier: workspace:*
+        version: link:../../core/loglayer
+      tsdown:
+        specifier: 0.20.3
+        version: 0.20.3(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(less@4.4.2)(tsx@4.21.0)
+
   packages/plugins/datadog-apm-trace-injector:
     dependencies:
       '@loglayer/plugin':


### PR DESCRIPTION
## Summary

Add `@loglayer/mixin-wide-events` package for wide event logging functionality.

## Features

- `withWideEvents(data)` - Accumulate data across async operations
- `getWideEvents(key?)` - Read accumulated data  
- `clearWideEvents(key?)` - Clear all or specific key
- `emitWideEvent(config)` - Emit wide event as comprehensive log entry

## Configuration Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `asyncContext` | `AsyncLocalStorage` | required | Async context for propagation |
| `includeContext` | `boolean` | `true` | Include `withContext()` data |
| `wideEventField` | `string` | `undefined` | Nest data under field |

## Safety Features

- Prototype pollution protection (`__proto__`, `constructor`, `prototype` blocked)
- Circular reference detection via `WeakSet`
- Deep merge for nested objects

## Documentation

- [Wide Events Mixin](/mixins/wide-events)
- [Event-Wide Logging Guide](/guides/event-wide-logging)

## Version

This is a **major** version bump (`1.0.0`) for the new package.