### PR TITLE
fix: add Deno and Bun badges to wide-events mixin

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -97,11 +97,12 @@ This project uses [OIDC (OpenID Connect) trusted publishing](https://docs.npmjs.
 
 For new packages, OIDC requires an initial manual publish:
 
-1. **Publish the first version manually** with OTP:
+1. **Publish the first version manually** with OTP at version `0.0.1`:
    ```bash
    cd packages/<new-package>
    npm publish --access public --otp=<code>
    ```
+   Using `0.0.1` ensures changesets can bump to `1.0.0` on the first release PR.
 2. **Configure trusted publisher** on npmjs.com:
    - Go to the package settings: `https://www.npmjs.com/settings/loglayer/packages/<package-name>/access`
    - Click **Settings** → **Publishing access**

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -89,6 +89,31 @@ Examples:
 - `feat: add datadog HTTP metrics mixin`
 - `fix(transport): handle null logger gracefully`
 
+## OIDC Publishing
+
+This project uses [OIDC (OpenID Connect) trusted publishing](https://docs.npmjs.com/about-oidc-trusted-publishing) for automated package releases via GitHub Actions.
+
+### First-Time Package Setup
+
+For new packages, OIDC requires an initial manual publish:
+
+1. **Publish the first version manually** with OTP:
+   ```bash
+   cd packages/<new-package>
+   npm publish --access public --otp=<code>
+   ```
+2. **Configure trusted publisher** on npmjs.com:
+   - Go to the package settings: `https://www.npmjs.com/settings/loglayer/packages/<package-name>/access`
+   - Click **Settings** → **Publishing access**
+   - Add GitHub Actions as a trusted publisher
+   - Set the workflow filename to `release.yml`
+   - Enable **"Require two-factor authentication and disallow tokens (recommended)"**
+3. **Future releases** will automatically use OIDC — no manual OTP needed
+
+### Why Manual First Publish?
+
+OIDC trusted publishing requires the package to already exist on npm. The initial publish establishes the trusted publisher relationship. Subsequent releases through GitHub Actions will have SLSA provenance enabled.
+
 ## Changesets
 
 **ALWAYS** create a changeset for any code changes to packages. Changesets are used to track changes and generate changelogs/version bumps.

--- a/docs/src/mixins/_partials/mixin-list.md
+++ b/docs/src/mixins/_partials/mixin-list.md
@@ -2,6 +2,6 @@
 
 | Name | Package | Description |
 |------|---------|-------------|
-| [Wide Events](/mixins/wide-events) <Badge type="tip" text="Server" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-wide-events)](https://www.npmjs.com/package/@loglayer/mixin-wide-events) | Adds wide event logging for comprehensive, self-contained log entries |
+| [Wide Events](/mixins/wide-events) <Badge type="tip" text="Server" /> <Badge type="info" text="Deno" /> <Badge type="info" text="Bun" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-wide-events)](https://www.npmjs.com/package/@loglayer/mixin-wide-events) | Adds wide event logging for comprehensive, self-contained log entries |
 | [Datadog Metrics (HTTP)](/mixins/datadog-http-metrics) <Badge type="tip" text="Server" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-datadog-http-metrics)](https://www.npmjs.com/package/@loglayer/mixin-datadog-http-metrics) | Adds the [`datadog-metrics`](https://github.com/dbader/node-datadog-metrics) API to LogLayer |
 | [Hot-Shots (StatsD)](/mixins/hot-shots) <Badge type="tip" text="Server" /> | [![npm](https://img.shields.io/npm/v/@loglayer/mixin-hot-shots)](https://www.npmjs.com/package/@loglayer/mixin-hot-shots) | Adds the [`hot-shots`](https://github.com/bdeitte/hot-shots) API to LogLayer |


### PR DESCRIPTION
Adds missing Deno and Bun environment badges to the Wide Events mixin in the mixin list partial. Also documents OIDC trusted publishing setup for new packages.