### PR TITLE
chore: migrate to TypeScript 6

### DIFF
--- a/.changeset/ts6-migration.md
+++ b/.changeset/ts6-migration.md
@@ -1,0 +1,18 @@
+---
+"@internal/tsconfig": patch
+"@loglayer/express": patch
+"@loglayer/koa": patch
+"@loglayer/bunyan": patch
+"@loglayer/opentelemetry": patch
+"@loglayer/pretty-terminal": patch
+"@loglayer/signale": patch
+"@loglayer/simple-pretty-terminal": patch
+---
+
+chore: migrate to TypeScript 6
+
+- Removed deprecated `esModuleInterop: false` (now always true in TS6)
+- Added `types: ["node"]` to base config (TS6 changed default behavior)
+- Added ES2024 lib for Symbol.dispose support
+- Updated packages with additional @types dependencies
+- Fixed unnecessary type assertions in eslint-tests (TS6 type inference improvement)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lefthook": "2.1.8",
     "syncpack": "15.3.1",
     "turbo": "2.9.14",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "engines": {
     "node": ">=20.16.0"

--- a/packages/context-managers/isolated/package.json
+++ b/packages/context-managers/isolated/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/context-managers/linked/package.json
+++ b/packages/context-managers/linked/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/context-manager/package.json
+++ b/packages/core/context-manager/package.json
@@ -48,7 +48,7 @@
     "@internal/tsconfig": "workspace:*",
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/eslint-tests/package.json
+++ b/packages/core/eslint-tests/package.json
@@ -16,7 +16,7 @@
     "@typescript-eslint/eslint-plugin": "8.59.4",
     "@typescript-eslint/parser": "8.59.4",
     "eslint": "10.4.0",
-    "typescript": "5.9.3",
-    "typescript-eslint": "8.55.0"
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.59.4"
   }
 }

--- a/packages/core/eslint-tests/src/plugins.ts
+++ b/packages/core/eslint-tests/src/plugins.ts
@@ -128,7 +128,7 @@ function testPluginOnBeforeDataOut() {
       {
         id: "data-out-plugin",
         onBeforeDataOut: ({ data }) => {
-          return { ...data, extra: "field" } as Record<string, unknown>;
+          return { ...data, extra: "field" };
         },
       },
     ],
@@ -152,7 +152,7 @@ function testPluginOnBeforeDataOut() {
   // Plugin that inspects logLevel in params
   const levelAware: LogLayerPlugin = {
     onBeforeDataOut: ({ logLevel, data }) => {
-      return { ...data, processedLevel: logLevel } as Record<string, unknown>;
+      return { ...data, processedLevel: logLevel };
     },
   };
   const logLevel = new LogLayer({
@@ -420,7 +420,7 @@ function testPluginCombinations() {
     id: "full-plugin",
     onMetadataCalled: () => ({ from: "plugin" }),
     onContextCalled: () => ({ from: "plugin" }),
-    onBeforeDataOut: ({ data }) => ({ ...data, enriched: true } as Record<string, unknown>),
+    onBeforeDataOut: ({ data }) => ({ ...data, enriched: true }),
     onBeforeMessageOut: () => ["(plugin) message"],
     shouldSendToLogger: () => true,
     transformLogLevel: () => null,
@@ -445,7 +445,7 @@ function testPluginCombinations() {
   };
   const plugin2: LogLayerPlugin = {
     id: "plugin-2",
-    onBeforeDataOut: ({ data }) => ({ ...data, step: 2 } as Record<string, unknown>),
+    onBeforeDataOut: ({ data }) => ({ ...data, step: 2 }),
   };
   const plugin3: LogLayerPlugin = {
     id: "plugin-3",
@@ -522,7 +522,7 @@ function testPluginManagement() {
 
   // Add multiple
   log.addPlugins([
-    { id: "extra-1", onBeforeDataOut: ({ data }) => ({ ...data, extra1: true } as Record<string, unknown>) },
+    { id: "extra-1", onBeforeDataOut: ({ data }) => ({ ...data, extra1: true }) },
     { id: "extra-2", shouldSendToLogger: () => true },
   ]);
   log.withMetadata({ key: "value" }).info("multiple plugins added");

--- a/packages/core/log-level-manager/package.json
+++ b/packages/core/log-level-manager/package.json
@@ -48,7 +48,7 @@
     "@internal/tsconfig": "workspace:*",
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/loglayer/package.json
+++ b/packages/core/loglayer/package.json
@@ -68,7 +68,7 @@
     "@internal/tsconfig": "workspace:*",
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -44,7 +44,7 @@
     "@internal/tsconfig": "workspace:*",
     "@types/node": "25.9.1",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -40,7 +40,7 @@
     "@internal/tsconfig": "workspace:*",
     "@types/node": "25.9.1",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/transport/package.json
+++ b/packages/core/transport/package.json
@@ -45,7 +45,7 @@
     "@internal/tsconfig": "workspace:*",
     "@types/node": "25.9.1",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/core/tsconfig/tsconfig.json
+++ b/packages/core/tsconfig/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ES2024"],
+    "types": ["node"],
     "sourceMap": true,
     "strict": true,
     "noImplicitAny": false,
@@ -10,7 +11,6 @@
     "moduleResolution": "NodeNext",
     "isolatedModules": true,
     "skipLibCheck": true,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true

--- a/packages/integrations/elysia/package.json
+++ b/packages/integrations/elysia/package.json
@@ -54,7 +54,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/integrations/express/package.json
+++ b/packages/integrations/express/package.json
@@ -53,7 +53,7 @@
     "supertest": "7.2.2",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/integrations/express/tsconfig.json
+++ b/packages/integrations/express/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "types": ["node", "express", "supertest"]
+  }
 }

--- a/packages/integrations/fastify/package.json
+++ b/packages/integrations/fastify/package.json
@@ -54,7 +54,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/integrations/hono/package.json
+++ b/packages/integrations/hono/package.json
@@ -51,7 +51,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/integrations/koa/package.json
+++ b/packages/integrations/koa/package.json
@@ -53,7 +53,7 @@
     "supertest": "7.2.2",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/integrations/koa/tsconfig.json
+++ b/packages/integrations/koa/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "types": ["node", "koa", "supertest"]
+  }
 }

--- a/packages/log-level-managers/global/package.json
+++ b/packages/log-level-managers/global/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/log-level-managers/linked/package.json
+++ b/packages/log-level-managers/linked/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/log-level-managers/one-way/package.json
+++ b/packages/log-level-managers/one-way/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/mixins/datadog-http-metrics/package.json
+++ b/packages/mixins/datadog-http-metrics/package.json
@@ -51,7 +51,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/mixins/hot-shots/package.json
+++ b/packages/mixins/hot-shots/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/mixins/wide-events/package.json
+++ b/packages/mixins/wide-events/package.json
@@ -46,7 +46,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {},

--- a/packages/plugins/datadog-apm-trace-injector/package.json
+++ b/packages/plugins/datadog-apm-trace-injector/package.json
@@ -57,7 +57,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/plugins/filter/package.json
+++ b/packages/plugins/filter/package.json
@@ -50,7 +50,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/plugins/opentelemetry/package.json
+++ b/packages/plugins/opentelemetry/package.json
@@ -60,7 +60,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/plugins/redaction/package.json
+++ b/packages/plugins/redaction/package.json
@@ -52,7 +52,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/plugins/sprintf/package.json
+++ b/packages/plugins/sprintf/package.json
@@ -51,7 +51,7 @@
     "@types/sprintf-js": "1.1.4",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/aws-cloudwatch-logs/package.json
+++ b/packages/transports/aws-cloudwatch-logs/package.json
@@ -51,7 +51,7 @@
     "rolldown": "1.0.0-beta.43",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/aws-lambda-powertools/package.json
+++ b/packages/transports/aws-lambda-powertools/package.json
@@ -51,7 +51,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/axiom/package.json
+++ b/packages/transports/axiom/package.json
@@ -50,7 +50,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/betterstack/package.json
+++ b/packages/transports/betterstack/package.json
@@ -53,7 +53,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/bunyan/package.json
+++ b/packages/transports/bunyan/package.json
@@ -50,7 +50,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/bunyan/tsconfig.json
+++ b/packages/transports/bunyan/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "types": ["node", "bunyan"]
+  }
 }

--- a/packages/transports/central/package.json
+++ b/packages/transports/central/package.json
@@ -49,7 +49,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/consola/package.json
+++ b/packages/transports/consola/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/cribl-http/package.json
+++ b/packages/transports/cribl-http/package.json
@@ -53,7 +53,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/datadog-browser-logs/package.json
+++ b/packages/transports/datadog-browser-logs/package.json
@@ -51,7 +51,7 @@
     "global-jsdom": "29.0.0",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/datadog/package.json
+++ b/packages/transports/datadog/package.json
@@ -51,7 +51,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/dynatrace/package.json
+++ b/packages/transports/dynatrace/package.json
@@ -50,7 +50,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/electron-log/package.json
+++ b/packages/transports/electron-log/package.json
@@ -46,7 +46,7 @@
     "@types/node": "25.9.1",
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/google-cloud-logging/package.json
+++ b/packages/transports/google-cloud-logging/package.json
@@ -56,7 +56,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/http/package.json
+++ b/packages/transports/http/package.json
@@ -51,7 +51,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/log-file-rotation/package.json
+++ b/packages/transports/log-file-rotation/package.json
@@ -54,7 +54,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/log4js-node/package.json
+++ b/packages/transports/log4js-node/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/logflare/package.json
+++ b/packages/transports/logflare/package.json
@@ -52,7 +52,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/loglevel/package.json
+++ b/packages/transports/loglevel/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/logtape/package.json
+++ b/packages/transports/logtape/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/new-relic/package.json
+++ b/packages/transports/new-relic/package.json
@@ -54,7 +54,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/opentelemetry/package.json
+++ b/packages/transports/opentelemetry/package.json
@@ -61,7 +61,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/opentelemetry/tsconfig.json
+++ b/packages/transports/opentelemetry/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "types": ["node", "express"]
+  }
 }

--- a/packages/transports/pino/package.json
+++ b/packages/transports/pino/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/pretty-terminal/package.json
+++ b/packages/transports/pretty-terminal/package.json
@@ -61,7 +61,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",
   "engines": {

--- a/packages/transports/pretty-terminal/tsconfig.json
+++ b/packages/transports/pretty-terminal/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
   "include": ["./src/**/*"],
-  "exclude": ["./src/__tests__/livetest-bun-sqlite.ts"]
+  "exclude": ["./src/__tests__/livetest-bun-sqlite.ts"],
+  "compilerOptions": {
+    "types": ["node", "better-sqlite3", "keypress"]
+  }
 }

--- a/packages/transports/roarr/package.json
+++ b/packages/transports/roarr/package.json
@@ -50,7 +50,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/sentry/package.json
+++ b/packages/transports/sentry/package.json
@@ -52,7 +52,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/signale/package.json
+++ b/packages/transports/signale/package.json
@@ -50,7 +50,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/signale/tsconfig.json
+++ b/packages/transports/signale/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "types": ["node", "signale"]
+  }
 }

--- a/packages/transports/simple-pretty-terminal/package.json
+++ b/packages/transports/simple-pretty-terminal/package.json
@@ -60,7 +60,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/simple-pretty-terminal/tsconfig.json
+++ b/packages/transports/simple-pretty-terminal/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@internal/tsconfig/tsconfig.json",
-  "include": ["./src/**/*"]
-} 
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "types": ["node", "chalk", "express", "sprintf-js"]
+  }
+}

--- a/packages/transports/sumo-logic/package.json
+++ b/packages/transports/sumo-logic/package.json
@@ -50,7 +50,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/tracer/package.json
+++ b/packages/transports/tracer/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/tslog/package.json
+++ b/packages/transports/tslog/package.json
@@ -49,7 +49,7 @@
     "loglayer": "workspace:*",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/packages/transports/victoria-logs/package.json
+++ b/packages/transports/victoria-logs/package.json
@@ -50,7 +50,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "bugs": "https://github.com/loglayer/loglayer/issues",

--- a/packages/transports/winston/package.json
+++ b/packages/transports/winston/package.json
@@ -50,7 +50,7 @@
     "serialize-error": "13.0.1",
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.7"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.31.0(@types/node@25.9.1)
       '@commitlint/cli':
         specifier: 21.0.1
-        version: 21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: 21.0.1
         version: 21.0.1
@@ -39,27 +39,27 @@ importers:
         specifier: 2.9.14
         version: 2.9.14
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   docs:
     dependencies:
       '@nolebase/ui-asciinema':
         specifier: 2.18.2
-        version: 2.18.2(asciinema-player@3.15.1)(vitepress@1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))
+        version: 2.18.2(asciinema-player@3.15.1)(vitepress@1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3))(vue@3.5.22(typescript@6.0.3))
       asciinema-player:
         specifier: 3.15.1
         version: 3.15.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
     devDependencies:
       glob:
         specifier: 13.0.6
         version: 13.0.6
       vitepress:
         specifier: 1.6.4
-        version: 1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3)
 
   packages/context-managers/isolated:
     dependencies:
@@ -78,10 +78,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -103,10 +103,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -125,10 +125,10 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -140,26 +140,26 @@ importers:
         version: link:../loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
     devDependencies:
       '@internal/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@typescript-eslint/eslint-plugin':
         specifier: 8.59.4
-        version: 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 8.59.4
-        version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       eslint:
         specifier: 10.4.0
         version: 10.4.0(jiti@2.6.1)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       typescript-eslint:
-        specifier: 8.55.0
-        version: 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.59.4
+        version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
 
   packages/core/log-level-manager:
     dependencies:
@@ -175,10 +175,10 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -209,10 +209,10 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -231,10 +231,10 @@ importers:
         version: 25.9.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -249,10 +249,10 @@ importers:
         version: 25.9.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -271,10 +271,10 @@ importers:
         version: 25.9.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -283,13 +283,13 @@ importers:
     dependencies:
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
 
   packages/integrations/elysia:
     devDependencies:
       '@elysiajs/node':
         specifier: 1.4.5
-        version: 1.4.5(elysia@1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@5.9.3))
+        version: 1.4.5(elysia@1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@6.0.3))
       '@internal/tsconfig':
         specifier: workspace:*
         version: link:../../core/tsconfig
@@ -301,7 +301,7 @@ importers:
         version: 25.9.1
       elysia:
         specifier: 1.4.28
-        version: 1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@5.9.3)
+        version: 1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@6.0.3)
       loglayer:
         specifier: workspace:*
         version: link:../../core/loglayer
@@ -310,13 +310,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -352,13 +352,13 @@ importers:
         version: 7.2.2
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -389,13 +389,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -425,13 +425,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -467,13 +467,13 @@ importers:
         version: 7.2.2
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -495,10 +495,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -520,10 +520,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -545,10 +545,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -573,10 +573,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -601,13 +601,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -628,10 +628,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -662,13 +662,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -696,10 +696,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -751,13 +751,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -788,10 +788,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -822,10 +822,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -853,13 +853,13 @@ importers:
         version: 1.0.0-beta.43
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -884,13 +884,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -915,13 +915,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -952,13 +952,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -986,13 +986,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1017,10 +1017,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1045,13 +1045,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1082,13 +1082,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1116,10 +1116,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1147,10 +1147,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1175,13 +1175,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1206,10 +1206,10 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1237,13 +1237,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1271,13 +1271,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1302,13 +1302,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1333,13 +1333,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1370,13 +1370,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1401,13 +1401,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1432,13 +1432,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1469,13 +1469,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1530,13 +1530,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1561,13 +1561,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1616,13 +1616,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/transports/roarr:
     dependencies:
@@ -1647,13 +1647,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1684,13 +1684,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1718,13 +1718,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1770,13 +1770,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1801,13 +1801,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1832,13 +1832,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1863,13 +1863,13 @@ importers:
         version: link:../../core/loglayer
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1900,13 +1900,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -1934,13 +1934,13 @@ importers:
         version: 13.0.1
       tsdown:
         specifier: 0.22.0
-        version: 0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27)
+        version: 0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@27.0.0(postcss@8.5.6))(vite@7.1.9(@types/node@25.9.1)(jiti@2.6.1)(less@4.4.2)(tsx@4.22.3))
@@ -4454,14 +4454,6 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
-  '@typescript-eslint/eslint-plugin@8.55.0':
-    resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.55.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/eslint-plugin@8.59.4':
     resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4470,13 +4462,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.55.0':
-    resolution: {integrity: sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/parser@8.59.4':
     resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4484,44 +4469,21 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.55.0':
-    resolution: {integrity: sha512-zRcVVPFUYWa3kNnjaZGXSu3xkKV1zXy8M4nO/pElzQhFweb7PPtluDLQtKArEOGmjXoRjnUZ29NjOiF0eCDkcQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/project-service@8.59.4':
     resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.55.0':
-    resolution: {integrity: sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.59.4':
     resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.55.0':
-    resolution: {integrity: sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/tsconfig-utils@8.59.4':
     resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.55.0':
-    resolution: {integrity: sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@8.59.4':
     resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
@@ -4530,19 +4492,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.55.0':
-    resolution: {integrity: sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.59.4':
     resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.55.0':
-    resolution: {integrity: sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/typescript-estree@8.59.4':
     resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
@@ -4550,23 +4502,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.55.0':
-    resolution: {integrity: sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/utils@8.59.4':
     resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/visitor-keys@8.55.0':
-    resolution: {integrity: sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.59.4':
     resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
@@ -5393,10 +5334,6 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@5.0.0:
     resolution: {integrity: sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==}
@@ -7271,12 +7208,6 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -7355,15 +7286,15 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript-eslint@8.55.0:
-    resolution: {integrity: sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw==}
+  typescript-eslint@8.59.4:
+    resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8448,11 +8379,11 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@commitlint/cli@21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/format': 21.0.1
       '@commitlint/lint': 21.0.1
-      '@commitlint/load': 21.0.1(@types/node@25.9.1)(typescript@5.9.3)
+      '@commitlint/load': 21.0.1(@types/node@25.9.1)(typescript@6.0.3)
       '@commitlint/read': 21.0.1(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.0.1
       tinyexec: 1.0.2
@@ -8497,14 +8428,14 @@ snapshots:
       '@commitlint/rules': 21.0.1
       '@commitlint/types': 21.0.1
 
-  '@commitlint/load@21.0.1(@types/node@25.9.1)(typescript@5.9.3)':
+  '@commitlint/load@21.0.1(@types/node@25.9.1)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.0.1
       '@commitlint/types': 21.0.1
-      cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -8684,10 +8615,10 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@elysiajs/node@1.4.5(elysia@1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@5.9.3))':
+  '@elysiajs/node@1.4.5(elysia@1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@6.0.3))':
     dependencies:
       crossws: 0.4.4(srvx@0.11.4)
-      elysia: 1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@5.9.3)
+      elysia: 1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@6.0.3)
       srvx: 0.11.4
 
   '@emnapi/core@1.10.0':
@@ -9169,12 +9100,12 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nolebase/ui-asciinema@2.18.2(asciinema-player@3.15.1)(vitepress@1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))':
+  '@nolebase/ui-asciinema@2.18.2(asciinema-player@3.15.1)(vitepress@1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3))(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       asciinema-player: 3.15.1
       less: 4.4.2
-      vitepress: 1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)
-      vue: 3.5.22(typescript@5.9.3)
+      vitepress: 1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   '@opentelemetry/api-logs@0.203.0':
     dependencies:
@@ -10563,182 +10494,91 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/type-utils': 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.55.0
-      eslint: 10.4.0(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.4
-      '@typescript-eslint/type-utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.4
       eslint: 10.4.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.55.0
-      debug: 4.4.3
-      eslint: 10.4.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.4
       '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       eslint: 10.4.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.55.0
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.59.4(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.4
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/scope-manager@8.55.0':
-    dependencies:
-      '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/visitor-keys': 8.55.0
 
   '@typescript-eslint/scope-manager@8.59.4':
     dependencies:
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
 
-  '@typescript-eslint/tsconfig-utils@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
-  '@typescript-eslint/type-utils@8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.4.0(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 10.4.0(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/types@8.55.0': {}
 
   '@typescript-eslint/types@8.59.4': {}
 
-  '@typescript-eslint/typescript-estree@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/visitor-keys': 8.55.0
-      debug: 4.4.3
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.3
       tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      eslint: 10.4.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.59.4
       '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
       eslint: 10.4.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/visitor-keys@8.55.0':
-    dependencies:
-      '@typescript-eslint/types': 8.55.0
-      eslint-visitor-keys: 4.2.1
 
   '@typescript-eslint/visitor-keys@8.59.4':
     dependencies:
@@ -10747,10 +10587,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@25.9.1)(less@4.4.2))(vue@3.5.22(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@25.9.1)(less@4.4.2))(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       vite: 5.4.20(@types/node@25.9.1)(less@4.4.2)
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -10857,28 +10697,28 @@ snapshots:
       '@vue/shared': 3.5.22
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.22
       '@vue/shared': 3.5.22
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   '@vue/shared@3.5.22': {}
 
-  '@vueuse/core@12.8.2(typescript@5.9.3)':
+  '@vueuse/core@12.8.2(typescript@6.0.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.22(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.22(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.6.5)(typescript@5.9.3)':
+  '@vueuse/integrations@12.8.2(focus-trap@7.6.5)(typescript@6.0.3)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.22(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.22(typescript@6.0.3)
     optionalDependencies:
       focus-trap: 7.6.5
     transitivePeerDependencies:
@@ -10886,9 +10726,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+  '@vueuse/shared@12.8.2(typescript@6.0.3)':
     dependencies:
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -11251,21 +11091,21 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 25.9.1
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.6.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   cross-fetch@3.2.0:
     dependencies:
@@ -11457,7 +11297,7 @@ snapshots:
 
   electron-log@5.4.3: {}
 
-  elysia@1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@5.9.3):
+  elysia@1.4.28(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.0)(openapi-types@12.1.3)(typescript@6.0.3):
     dependencies:
       '@sinclair/typebox': 0.34.48
       cookie: 1.1.1
@@ -11467,7 +11307,7 @@ snapshots:
       memoirist: 0.4.0
       openapi-types: 12.1.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   emoji-regex-xs@1.0.0: {}
 
@@ -11626,8 +11466,6 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.0: {}
 
@@ -13113,7 +12951,7 @@ snapshots:
       safe-stable-stringify: 2.5.0
       semver-compare: 1.0.0
 
-  rolldown-plugin-dts@0.25.1(rolldown@1.0.2)(typescript@5.9.3):
+  rolldown-plugin-dts@0.25.1(rolldown@1.0.2)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.5
       '@babel/helper-validator-identifier': 8.0.0-rc.5
@@ -13125,7 +12963,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -13677,15 +13515,11 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
-  tsdown@0.22.0(tsx@4.22.3)(typescript@5.9.3)(unrun@0.2.27):
+  tsdown@0.22.0(tsx@4.22.3)(typescript@6.0.3)(unrun@0.2.27):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -13696,7 +13530,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.2
-      rolldown-plugin-dts: 0.25.1(rolldown@1.0.2)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.25.1(rolldown@1.0.2)(typescript@6.0.3)
       semver: 7.8.1
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
@@ -13704,7 +13538,7 @@ snapshots:
       unconfig-core: 7.5.0
     optionalDependencies:
       tsx: 4.22.3
-      typescript: 5.9.3
+      typescript: 6.0.3
       unrun: 0.2.27(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@ts-macro/tsc'
@@ -13755,18 +13589,18 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
-  typescript-eslint@8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       eslint: 10.4.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uint8array-extras@1.5.0: {}
 
@@ -13867,7 +13701,7 @@ snapshots:
       less: 4.4.2
       tsx: 4.22.3
 
-  vitepress@1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.40.0)(@types/node@25.9.1)(less@4.4.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.40.0)(search-insights@2.17.3)
@@ -13876,17 +13710,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@25.9.1)(less@4.4.2))(vue@3.5.22(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@25.9.1)(less@4.4.2))(vue@3.5.22(typescript@6.0.3))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.22
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.6.5)(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.6.5)(typescript@6.0.3)
       focus-trap: 7.6.5
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 5.4.20(@types/node@25.9.1)(less@4.4.2)
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.6
     transitivePeerDependencies:
@@ -13945,15 +13779,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vue@3.5.22(typescript@5.9.3):
+  vue@3.5.22(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.22
       '@vue/compiler-sfc': 3.5.22
       '@vue/runtime-dom': 3.5.22
-      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@6.0.3))
       '@vue/shared': 3.5.22
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Migrate the codebase from TypeScript 5 to TypeScript 6 following the [official migration guide](https://aka.ms/ts6).

## Changes

### Base tsconfig (`packages/core/tsconfig/tsconfig.json`)
- Removed deprecated `esModuleInterop: false` (now always \`true\` in TS6)
- Added \`types: ["node"]\` to base config (TS6 changed default from auto-include all to \`[]\`)
- Added ES2024 lib for \`Symbol.dispose\` support

### Package-specific tsconfigs
Packages with additional \`@types\` dependencies now override with their own \`types\` array:

| Package | Additional Types |
|---------|-----------------|
| \`integrations/express\` | \`express\`, \`supertest\` |
| \`integrations/koa\` | \`koa\`, \`supertest\` |
| \`transports/bunyan\` | \`bunyan\` |
| \`transports/opentelemetry\` | \`express\` |
| \`transports/pretty-terminal\` | \`better-sqlite3\`, \`keypress\` |
| \`transports/signale\` | \`signale\` |
| \`transports/simple-pretty-terminal\` | \`chalk\`, \`express\`, \`sprintf-js\` |

### Bug fixes
- Fixed unnecessary type assertions in \`eslint-tests/src/plugins.ts\` (TS6 type inference improvement)

## Verification

- ✅ Build: 56/56 packages
- ✅ Verify types: 62/62 packages  
- ✅ Tests: 58/58 tasks

## Related

See the [TypeScript 6 migration guide](https://aka.ms/ts6) for details on all deprecations.