### PR TITLE
feat(mixin-wide-events): add withWideEventError helper method

### DIFF
--- a/.changeset/wide-events-error-handling.md
+++ b/.changeset/wide-events-error-handling.md
@@ -1,0 +1,14 @@
+---
+"@loglayer/mixin-wide-events": patch
+---
+
+feat: add withWideEventError helper method
+
+Add `withWideEventError()` method for capturing errors in wide event log entries:
+
+- New `withWideEventError(error)` method for capturing errors
+- Add `errorField` config option (defaults to `error` or `errors` for array mode)
+- Add `errorsAsArray` config option for collecting multiple errors as array
+- Uses LogLayer's `errorSerializer` if configured
+- `emitWideEvent()` now returns void (not chainable)
+- Remove `metadata` option from EmitWideEventConfig

--- a/docs/src/guides/wide-events.md
+++ b/docs/src/guides/wide-events.md
@@ -156,15 +156,8 @@ app.post("/api/orders", async (req, res) => {
     // Immediate log with stack trace
     logger.withError(error as Error).error("Order failed");
     
-    // Capture error details for wide event
-    if (error instanceof Error) {
-      logger.withWideEvents({
-        error: {
-          type: error.name,
-          message: error.message,
-        },
-      });
-    }
+    // Capture error for wide event
+    logger.withWideEventError(error);
     
     res.status(500).json({ error: "Failed to create order" });
   }

--- a/docs/src/guides/wide-events.md
+++ b/docs/src/guides/wide-events.md
@@ -153,7 +153,19 @@ app.post("/api/orders", async (req, res) => {
 
     res.status(201).json(order);
   } catch (error) {
+    // Immediate log with stack trace
     logger.withError(error as Error).error("Order failed");
+    
+    // Capture error details for wide event
+    if (error instanceof Error) {
+      logger.withWideEvents({
+        error: {
+          type: error.name,
+          message: error.message,
+        },
+      });
+    }
+    
     res.status(500).json({ error: "Failed to create order" });
   }
 

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -117,6 +117,8 @@ const mixin = createWideEventMixin({
 |------|------|---------|-------------|
 | `includeContext` | `boolean` | `true` | Include data from `withContext()` calls in the emitted wide event. |
 | `wideEventField` | `string` | `undefined` | Field name to nest all wide event data under. When undefined, data is flattened at root level. |
+| `errorField` | `string` | `error`/`errors` | Field name for error data. `error` in single mode, `errors` in array mode. |
+| `errorsAsArray` | `boolean` | `false` | When true, errors are collected as an array. Each call to `withWideEventError()` appends. |
 
 ### `withWideEvents(data)`
 
@@ -184,6 +186,46 @@ logger.emitWideEvent({ message: "Second" });
 logger.withWideEvents({ user: { id: "123", name: "Alice" } });
 logger.clearWideEvents("user");
 // Result: user object is removed
+```
+
+### `withWideEventError(error)`
+
+`(error: any) => this`
+
+Captures an error for inclusion in the wide event. Serializes the error using LogLayer's [`errorSerializer`](/configuration#error-handling-configuration) (or built-in default).
+
+By default:
+- **Single error mode** (`errorsAsArray: false`): Each call replaces the previous error
+- **Array mode** (`errorsAsArray: true`): Each call appends to an `errors` array
+
+The error field defaults to `error` for single mode and `errors` for array mode.
+
+```typescript
+// Single error (replaces on subsequent calls)
+try {
+  await doSomething();
+} catch (err) {
+  logger.withWideEventError(err);
+}
+
+// Multiple errors (accumulates when errorsAsArray: true)
+try {
+  await step1();
+} catch (err) {
+  logger.withWideEventError(err);
+}
+
+try {
+  await step2();
+} catch (err) {
+  logger.withWideEventError(err);
+}
+
+// With array mode for multiple errors
+const mixin = createWideEventMixin({
+  asyncContext,
+  errorsAsArray: true,
+});
 ```
 
 ### `emitWideEvent(config)`
@@ -267,7 +309,7 @@ logger.emitWideEvent({ message: "Complete" });
 Wide events and `withError()` serve different purposes:
 
 - **`withError(err).error("msg")`** - Logs an error immediately with stack trace and error details
-- **`withWideEvents({ error: {...} })`** - Captures error information for the final wide event
+- **`withWideEventError(err)`** - Captures error for inclusion in the wide event
 
 The [canonical logging pattern](https://loggingsucks.com/) recommends including error details in your wide event rather than relying on `withError()`. This keeps all operation data in one self-contained entry.
 
@@ -278,47 +320,26 @@ try {
   // Immediate error log with stack trace
   logger.withError(err).error("Order processing failed");
   
-  // Error details for wide event
-  logger.withWideEvents({
-    error: {
-      type: err.name,
-      message: err.message,
-      code: err.code,
-    },
-  });
+  // Error for wide event
+  logger.withWideEventError(err);
   
   // Don't emit yet - let the response handler emit with final status
 }
 ```
 
-### Helper Function Pattern
-
-For cleaner code, create a helper to capture error details:
+### Configuration Options
 
 ```typescript
-function captureError(logger: ILogLayer, error: unknown) {
-  if (error instanceof Error) {
-    return {
-      type: error.name,
-      message: error.message,
-      code: (error as any).code,
-      stack: error.stack,
-    };
-  }
-  return { message: String(error) };
-}
-
-// Usage
-try {
-  await doSomething();
-} catch (err) {
-  getLogger()
-    .withError(err)
-    .error("Operation failed");
-  getLogger()
-    .withWideEvents({ error: captureError(getLogger(), err) });
-}
+const mixin = createWideEventMixin({
+  asyncContext,
+  // Default field names: "error" (single) or "errors" (array mode)
+  errorField: "error",
+  // Set to true to collect multiple errors as an array
+  errorsAsArray: false,
+});
 ```
+
+The error serializer uses LogLayer's configured [`errorSerializer`](/configuration#error-handling-configuration) if available.
 
 ### Emitting Error Wide Events
 
@@ -402,16 +423,8 @@ app.post("/orders", async (req, res) => {
     // Immediate log with stack trace
     logger.withError(err).error("Order creation failed");
     
-    // Error details for wide event
-    if (err instanceof Error) {
-      logger.withWideEvents({
-        error: {
-          type: err.name,
-          message: err.message,
-          code: (err as any).code,
-        },
-      });
-    }
+    // Capture error for wide event
+    logger.withWideEventError(err);
     
     res.status(500).json({ error: "Failed to create order" });
   }

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -230,25 +230,22 @@ const mixin = createWideEventMixin({
 
 ### `emitWideEvent(config)`
 
-`(config: { message: string; level?: LogLevelType; metadata?: Record<string, any> }) => this`
+`(config: EmitWideEventConfig) => void`
 
-Emits the accumulated wide event as a single log entry. Returns the logger
-for chaining.
+Emits the accumulated wide event as a single log entry. Use `withWideEvents()`
+before calling this to add any additional data.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `message` | `string` | - | The log message for the wide event. |
 | `level` | `LogLevelType` | `"info"` | The log level for the emission. |
-| `metadata` | `Record<string, any>` | `undefined` | Additional metadata to include in this emission. |
 
 ```typescript
 logger.emitWideEvent({ message: "Order processed" });
 
-// Or chain with other operations
-logger
-  .withWideEvents({ statusCode: 200 })
-  .emitWideEvent({ message: "Request completed" })
-  .info("After emitting");
+// Add final data before emitting
+logger.withWideEvents({ statusCode: 200 });
+logger.emitWideEvent({ message: "Request completed", level: "error" });
 ```
 
 ### Data Priority
@@ -256,8 +253,7 @@ logger
 When multiple sources provide the same key, the following priority order applies:
 
 1. **`withContext()`** data (lowest priority)
-2. **`withWideEvents()`** data
-3. **`emitWideEvent({ metadata: {...} })`** data (highest priority)
+2. **`withWideEvents()`** data (highest priority)
 
 Top-level keys are overwritten by later calls. Nested objects are **deep merged**.
 

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -262,6 +262,83 @@ logger.emitWideEvent({ message: "Complete" });
 // Wide event: { msg: "Complete", businessData: "value" }
 ```
 
+## Capturing Errors
+
+Wide events and `withError()` serve different purposes:
+
+- **`withError(err).error("msg")`** - Logs an error immediately with stack trace and error details
+- **`withWideEvents({ error: {...} })`** - Captures error information for the final wide event
+
+The [canonical logging pattern](https://loggingsucks.com/) recommends including error details in your wide event rather than relying on `withError()`. This keeps all operation data in one self-contained entry.
+
+```typescript
+try {
+  await processOrder(orderId);
+} catch (err) {
+  // Immediate error log with stack trace
+  logger.withError(err).error("Order processing failed");
+  
+  // Error details for wide event
+  logger.withWideEvents({
+    error: {
+      type: err.name,
+      message: err.message,
+      code: err.code,
+    },
+  });
+  
+  // Don't emit yet - let the response handler emit with final status
+}
+```
+
+### Helper Function Pattern
+
+For cleaner code, create a helper to capture error details:
+
+```typescript
+function captureError(logger: ILogLayer, error: unknown) {
+  if (error instanceof Error) {
+    return {
+      type: error.name,
+      message: error.message,
+      code: (error as any).code,
+      stack: error.stack,
+    };
+  }
+  return { message: String(error) };
+}
+
+// Usage
+try {
+  await doSomething();
+} catch (err) {
+  getLogger()
+    .withError(err)
+    .error("Operation failed");
+  getLogger()
+    .withWideEvents({ error: captureError(getLogger(), err) });
+}
+```
+
+### Emitting Error Wide Events
+
+When emitting a wide event after an error, set the level appropriately:
+
+```typescript
+res.on("finish", () => {
+  getLogger()
+    .withWideEvents({
+      duration: Date.now() - startTime,
+      statusCode: res.statusCode,
+      outcome: res.statusCode >= 400 ? "error" : "ok",
+    })
+    .emitWideEvent({
+      message: "Request completed",
+      level: res.statusCode >= 400 ? "error" : "info",
+    });
+});
+```
+
 ## Complete Example
 
 Here's a complete Express middleware example:
@@ -306,19 +383,52 @@ app.use((req, res, next) => {
   asyncLocalStorage.run({ logger }, next);
 });
 
-// Route handler - no wrapping needed!
-app.get("/orders/:id", (req, res) => {
-  getLogger().debug("Fetching order");
-  const order = getOrder(req.params.id);
-  
-  getLogger().withWideEvents({ orderId: order.id, items: order.items.length });
-  
+// Route handler with error handling
+app.post("/orders", async (req, res) => {
+  const logger = getLogger();
+  const startTime = Date.now();
+
+  logger.withWideEvents({ itemCount: req.body.items?.length ?? 0 });
+
+  try {
+    const order = await createOrder(req.body);
+    
+    logger
+      .withWideEvents({ orderId: order.id })
+      .info("Order created");
+    
+    res.status(201).json(order);
+  } catch (err) {
+    // Immediate log with stack trace
+    logger.withError(err).error("Order creation failed");
+    
+    // Error details for wide event
+    if (err instanceof Error) {
+      logger.withWideEvents({
+        error: {
+          type: err.name,
+          message: err.message,
+          code: (err as any).code,
+        },
+      });
+    }
+    
+    res.status(500).json({ error: "Failed to create order" });
+  }
+
+  // Emit wide event on response finish
   res.on("finish", () => {
-    getLogger().withWideEvents({ statusCode: res.statusCode });
-    getLogger().emitWideEvent({ message: "Request completed" });
+    logger
+      .withWideEvents({
+        duration: Date.now() - startTime,
+        statusCode: res.statusCode,
+        outcome: res.statusCode >= 400 ? "error" : "ok",
+      })
+      .emitWideEvent({
+        message: "Request completed",
+        level: res.statusCode >= 400 ? "error" : "info",
+      });
   });
-  
-  res.json(order);
 });
 ```
 

--- a/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
@@ -32,24 +32,25 @@ describe("Type Tests", () => {
     const result3 = logger.clearWideEvents();
     expectTypeOf(result3).toMatchTypeOf<ILogLayer>();
 
-    // emitWideEvent should return the logger type
-    const result4 = logger.emitWideEvent({ message: "test" });
-    expectTypeOf(result4).toMatchTypeOf<ILogLayer>();
+    // emitWideEvent returns void
+    logger.emitWideEvent({ message: "test" });
   });
 
   it("should allow method chaining", () => {
     const logger: ILogLayer = new LogLayer({ transport: {} as any });
 
-    // All methods should return the same type for chaining
+    // Most methods return the logger for chaining
     const result = logger
       .withWideEvents({ userId: "123" })
       .withWideEvents({ orderId: "456" })
       .withContext({ requestStart: Date.now() })
       .clearWideEvents()
-      .withWideEvents({ newRequest: "req-789" })
-      .emitWideEvent({ message: "New request completed" });
+      .withWideEvents({ newRequest: "req-789" });
 
     expectTypeOf(result).toMatchTypeOf<ILogLayer>();
+
+    // emitWideEvent returns void, call separately
+    logger.emitWideEvent({ message: "New request completed" });
   });
 
   it("should preserve LogLayer type", () => {
@@ -84,11 +85,5 @@ describe("Type Tests", () => {
     // All config options should be valid
     logger.emitWideEvent({ message: "msg" });
     logger.emitWideEvent({ message: "msg", level: "error" });
-    logger.emitWideEvent({ message: "msg", metadata: { extra: "data" } });
-    logger.emitWideEvent({
-      message: "msg",
-      level: "warn",
-      metadata: { code: 123 },
-    });
   });
 });

--- a/packages/mixins/wide-events/src/__tests__/wide-event.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/wide-event.test.ts
@@ -180,28 +180,6 @@ describe("WideEventMixin", () => {
     expect(emittedLogs[0].metadata).toEqual({ key: "from-wideEvents" });
   });
 
-  it("should prioritize emit metadata over withWideEvents for same key", () => {
-    const ctx = new AsyncLocalStorage();
-    useLogLayerMixin(createWideEventMixin({ asyncContext: ctx }));
-    const l = new LogLayer({
-      transport: new BlankTransport({
-        shipToLogger: (p) => {
-          emittedLogs.push({ metadata: p.metadata });
-          return p.messages;
-        },
-      }),
-    });
-
-    ctx.run({}, () => {
-      const logger = l.child();
-      logger.withWideEvents({ key: "from-wideEvents" });
-      logger.emitWideEvent({ message: "Test", metadata: { key: "from-emit" } });
-    });
-
-    // Emit metadata should override wideEvents
-    expect(emittedLogs[0].metadata).toEqual({ key: "from-emit" });
-  });
-
   it("should allow withMetadata and withWideEvents to work independently", () => {
     const ctx = new AsyncLocalStorage();
     useLogLayerMixin(createWideEventMixin({ asyncContext: ctx }));
@@ -264,14 +242,6 @@ describe("WideEventMixin", () => {
     asyncContext.run({}, () => {
       const logger = log.child();
       const result = logger.withWideEvents({ key: "value" });
-      expect(result).toBe(logger);
-    });
-  });
-
-  it("should return logger for emitWideEvent chaining", () => {
-    asyncContext.run({}, () => {
-      const logger = log.child();
-      const result = logger.emitWideEvent({ message: "test" });
       expect(result).toBe(logger);
     });
   });

--- a/packages/mixins/wide-events/src/__tests__/wide-event.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/wide-event.test.ts
@@ -481,4 +481,167 @@ describe("WideEventMixin", () => {
       expect(data.first.ref.ref).toBeDefined();
     });
   });
+
+  describe("withWideEventError", () => {
+    it("should capture error with default serializer", () => {
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        const testError = new Error("Something went wrong");
+        testError.name = "CustomError";
+
+        logger.withWideEventError(testError);
+        logger.emitWideEvent({ message: "Operation failed" });
+
+        expect(emittedLogs).toHaveLength(1);
+        expect(emittedLogs[0].metadata.error).toEqual({
+          name: "CustomError",
+          message: "Something went wrong",
+          stack: testError.stack,
+        });
+      });
+    });
+
+    it("should use custom error field name", () => {
+      const customContext = new AsyncLocalStorage<Record<string, any>>();
+      const customLog = new LogLayer({
+        transport: new BlankTransport({
+          shipToLogger: (params) => {
+            emittedLogs.push({
+              level: params.logLevel,
+              metadata: params.metadata,
+            });
+            return params.messages;
+          },
+        }),
+      });
+      const mixin = createWideEventMixin({
+        asyncContext: customContext,
+        errorField: "errorInfo",
+      });
+      useLogLayerMixin(mixin);
+
+      customContext.run({}, () => {
+        const logger = customLog.child();
+        logger.withWideEventError(new Error("Test error"));
+        logger.emitWideEvent({ message: "Done" });
+      });
+
+      expect(emittedLogs[0].metadata.errorInfo).toBeDefined();
+      expect(emittedLogs[0].metadata.error).toBeUndefined();
+    });
+
+    it("should use 'errors' field name by default when errorsAsArray is true", () => {
+      const customContext = new AsyncLocalStorage<Record<string, any>>();
+      const customLog = new LogLayer({
+        transport: new BlankTransport({
+          shipToLogger: (params) => {
+            emittedLogs.push({
+              level: params.logLevel,
+              metadata: params.metadata,
+            });
+            return params.messages;
+          },
+        }),
+      });
+      const mixin = createWideEventMixin({
+        asyncContext: customContext,
+        errorsAsArray: true,
+      });
+      useLogLayerMixin(mixin);
+
+      customContext.run({}, () => {
+        const logger = customLog.child();
+        logger.withWideEventError(new Error("First error"));
+        logger.withWideEventError(new Error("Second error"));
+        logger.emitWideEvent({ message: "Done" });
+      });
+
+      // Should use 'errors' (plural) by default when errorsAsArray is true
+      expect(emittedLogs[0].metadata.errors).toEqual([
+        { name: "Error", message: "First error", stack: expect.any(String) },
+        { name: "Error", message: "Second error", stack: expect.any(String) },
+      ]);
+      // Should NOT have 'error' field
+      expect(emittedLogs[0].metadata.error).toBeUndefined();
+    });
+
+    it("should replace error when errorsAsArray is false (default)", () => {
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.withWideEventError(new Error("First"));
+        logger.withWideEventError(new Error("Second"));
+        logger.emitWideEvent({ message: "Done" });
+      });
+
+      expect(emittedLogs[0].metadata.error).toEqual({
+        name: "Error",
+        message: "Second",
+        stack: expect.any(String),
+      });
+    });
+
+    it("should handle non-Error values with default serializer", () => {
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.withWideEventError("Just a string error");
+        logger.emitWideEvent({ message: "Done" });
+      });
+
+      expect(emittedLogs[0].metadata.error).toEqual({
+        message: "Just a string error",
+      });
+    });
+
+    it("should return logger for chaining", () => {
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        const result = logger.withWideEventError(new Error("test"));
+        expect(result).toBe(logger);
+      });
+    });
+
+    it("should silently ignore when not in async context", () => {
+      const logger = log.child();
+      const result = logger.withWideEventError(new Error("test"));
+      expect(result).toBe(logger);
+    });
+
+    it("should use LogLayer's errorSerializer when configured", () => {
+      const customContext = new AsyncLocalStorage<Record<string, any>>();
+      const loglayerErrorSerializer = (err: any) => ({
+        class: err.constructor.name,
+        text: err.message,
+        code: err.code || "NO_CODE",
+      });
+
+      const customLog = new LogLayer({
+        transport: new BlankTransport({
+          shipToLogger: (params) => {
+            emittedLogs.push({ metadata: params.metadata });
+            return params.messages;
+          },
+        }),
+        errorSerializer: loglayerErrorSerializer,
+      });
+      const mixin = createWideEventMixin({
+        asyncContext: customContext,
+        // No custom errorSerializer - should use LogLayer's
+      });
+      useLogLayerMixin(mixin);
+
+      customContext.run({}, () => {
+        const logger = customLog.child();
+        const err = new Error("Service unavailable");
+        (err as any).code = "SVC_DOWN";
+        logger.withWideEventError(err);
+        logger.emitWideEvent({ message: "Done" });
+      });
+
+      expect(emittedLogs[0].metadata.error).toEqual({
+        class: "Error",
+        text: "Service unavailable",
+        code: "SVC_DOWN",
+      });
+    });
+  });
 });

--- a/packages/mixins/wide-events/src/mixin.ts
+++ b/packages/mixins/wide-events/src/mixin.ts
@@ -226,11 +226,11 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
   /**
    * Implementation for emitWideEvent
    */
-  function emitWideEventImpl(config: EmitWideEventConfig, self: any): any {
+  function emitWideEventImpl(config: EmitWideEventConfig, self: any): void {
     const store = asyncContext.getStore();
 
-    // Build wide event data with priority order (later = higher priority)
-    // Priority: context < wideEvents < emit metadata
+    // Build wide event data with priority order
+    // Priority: context < wideEvents
     const wideEventData: Record<string, any> = {};
 
     // Include context data first (lowest priority)
@@ -243,11 +243,6 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
       Object.assign(wideEventData, store._llWideEvents);
     }
 
-    // Include emit config metadata last (highest priority, can override anything)
-    if (config.metadata) {
-      Object.assign(wideEventData, config.metadata);
-    }
-
     // Determine log level
     const level = config.level ?? "info";
 
@@ -256,8 +251,6 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
 
     // Emit the wide event with metadata
     self.withMetadata(metadataToEmit)[level](config.message);
-
-    return self;
   }
 
   /**

--- a/packages/mixins/wide-events/src/mixin.ts
+++ b/packages/mixins/wide-events/src/mixin.ts
@@ -55,6 +55,30 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
   const asyncContext = options.asyncContext;
   const includeContext = options.includeContext ?? true;
   const wideEventField = options.wideEventField;
+  const errorsAsArray = options.errorsAsArray ?? false;
+  // Default error field: "errors" for arrays, "error" for single
+  const errorField = options.errorField ?? (errorsAsArray ? "errors" : "error");
+
+  // Default error serializer - used if LogLayer has no errorSerializer configured
+  function defaultErrorSerializer(err: any): Record<string, any> {
+    if (err instanceof Error) {
+      return {
+        name: err.name,
+        message: err.message,
+        stack: err.stack,
+      };
+    }
+    return { message: String(err) };
+  }
+
+  // Get error serializer - uses LogLayer's if configured, otherwise default
+  function getErrorSerializer(self: any): (err: any) => Record<string, any> {
+    const config = self.getConfig?.();
+    if (config?.errorSerializer) {
+      return config.errorSerializer;
+    }
+    return defaultErrorSerializer;
+  }
 
   // Generate unique plugin ID to avoid conflicts
   const pluginId = `@loglayer/wide-events-context-tracker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -174,6 +198,32 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
   }
 
   /**
+   * Implementation for withWideEventError
+   */
+  function withWideEventErrorImpl(error: any, self: any): any {
+    const store = asyncContext.getStore();
+    if (store) {
+      const serializer = getErrorSerializer(self);
+      const serializedError = serializer(error);
+
+      if (errorsAsArray) {
+        // Append to array
+        if (!store._llWideEvents) {
+          store._llWideEvents = {};
+        }
+        if (!store._llWideEvents[errorField]) {
+          store._llWideEvents[errorField] = [];
+        }
+        store._llWideEvents[errorField].push(serializedError);
+      } else {
+        // Replace single error
+        withWideEventsImpl({ [errorField]: serializedError }, self);
+      }
+    }
+    return self;
+  }
+
+  /**
    * Implementation for emitWideEvent
    */
   function emitWideEventImpl(config: EmitWideEventConfig, self: any): any {
@@ -231,6 +281,10 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
       prototype.emitWideEvent = function (this: LogLayer, config: EmitWideEventConfig) {
         return emitWideEventImpl(config, this);
       };
+
+      prototype.withWideEventError = function (this: LogLayer, error: any) {
+        return withWideEventErrorImpl(error, this);
+      };
     },
     augmentMock: (prototype: any) => {
       prototype.withWideEvents = function (this: any, data: Record<string, any>) {
@@ -247,6 +301,10 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
 
       prototype.emitWideEvent = function (this: any, config: EmitWideEventConfig) {
         return emitWideEventImpl(config, this);
+      };
+
+      prototype.withWideEventError = function (this: any, error: any) {
+        return withWideEventErrorImpl(error, this);
       };
     },
   };

--- a/packages/mixins/wide-events/src/types.ts
+++ b/packages/mixins/wide-events/src/types.ts
@@ -32,6 +32,20 @@ export interface WideEventMixinOptions {
    * { "userId": "123", "orderId": "456", "msg": "done" }
    */
   wideEventField?: string;
+
+  /**
+   * Optional: Field name to use for error data in wide events.
+   * @default "error" (single mode) or "errors" (array mode)
+   */
+  errorField?: string;
+
+  /**
+   * Optional: When true, errors are collected as an array.
+   * Each call to withWideEventError() appends to the array.
+   * When false, each call replaces the previous error.
+   * @default false
+   */
+  errorsAsArray?: boolean;
 }
 
 /**
@@ -149,7 +163,29 @@ export interface IWideEventMixin {
    * ```
    */
   emitWideEvent(config: EmitWideEventConfig): this;
-}
+
+  /**
+   * Captures an error for inclusion in the wide event.
+   * Serializes the error using the configured errorSerializer (or default).
+   *
+   * @param error - The error to capture
+   * @returns This logger instance for chaining
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   await doSomething();
+   * } catch (err) {
+   *   // For single error (replaces previous)
+   *   logger.withWideEventError(err);
+   *   
+   *   // With errorsAsArray: true - errors accumulate
+   *   logger.withWideEventError(err).withWideEventError(otherErr);
+   * }
+   * ```
+   */
+  withWideEventError(error: any): this;
+};
 
 // Module augmentation for ILogLayer and ILogBuilder
 declare module "loglayer" {

--- a/packages/mixins/wide-events/src/types.ts
+++ b/packages/mixins/wide-events/src/types.ts
@@ -61,12 +61,6 @@ export interface EmitWideEventConfig {
    * Optional: Log level (defaults to "info").
    */
   level?: LogLevelType;
-
-  /**
-   * Optional: Additional metadata to include in this specific emission.
-   * This is merged with the accumulated wide event data.
-   */
-  metadata?: Record<string, any>;
 }
 
 /**
@@ -147,22 +141,20 @@ export interface IWideEventMixin {
    * and logs at the specified level.
    *
    * @param config - Configuration for the wide event emission
-   * @returns This logger instance for chaining
    *
    * @example
    * ```typescript
    * // Emit as info log
    * logger.emitWideEvent({ message: "Order processed" });
    *
-   * // Emit as error with additional metadata
+   * // Emit as error
    * logger.emitWideEvent({
    *   message: "Order failed",
    *   level: "error",
-   *   metadata: { reason: "payment_declined" }
    * });
    * ```
    */
-  emitWideEvent(config: EmitWideEventConfig): this;
+  emitWideEvent(config: EmitWideEventConfig): void;
 
   /**
    * Captures an error for inclusion in the wide event.


### PR DESCRIPTION
Add error handling support to @loglayer/mixin-wide-events with a new `withWideEventError()` helper method.