### PR TITLE
feat(mixin-wide-events): add sampling support for wide events

### DIFF
--- a/.changeset/wide-events-sampling.md
+++ b/.changeset/wide-events-sampling.md
@@ -1,0 +1,7 @@
+---
+"@loglayer/mixin-wide-events": minor
+---
+
+Add sampling configuration to the wide events mixin. Wide events can now be randomly
+dropped at a configured rate to control log volume. Supports two strategies: "default" (single rate) and "per_level" (per-level rates from a map, unmapped levels kept at 100%). A custom `shouldEmit` callback also accepts the accumulated wide event data and log level for content-aware filtering. "error" and "fatal" levels are always kept (100% sampled) regardless of rate or callback.
+

--- a/docs/src/cheatsheet.md
+++ b/docs/src/cheatsheet.md
@@ -389,3 +389,5 @@ See [Basic Logging](/logging-api/basic-logging#raw-logging) for context behavior
 | Log error only | `log.errorOnly(err)` | Single entry |
 | Log metadata only | `log.metadataOnly({...})` | Single entry |
 | Mock for tests | `new MockLogLayer()` | - |
+| Wide events mixin | `@loglayer/mixin-wide-events` | Accmulate data across async boundaries and emit as single log entry (canonical log line). Supports sampling with `error`/`fatal` always kept. |
+| Create wide event mixin | `createWideEventMixin({ asyncContext, sampling: { strategy: 'default', rate: 0.1 } })` | - |

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,8 +33,8 @@ features:
     details: Fan out logs to multiple logging libraries like Pino and cloud providers like DataDog at the same time.
   - title: OpenTelemetry Support
     details: A transport and plugin is available for connecting logs to OpenTelemetry.
-  - title: StatsD Support
-    details: A mixin is available to add methods to LogLayer to easily send metrics with your logs to StatsD.
+  - title: Wide Event Logging
+    details: Capture rich, self-contained log entries that span async boundaries using the Wide Events mixin.
   - title: HTTP Support
     details: A transport is available to send logs via HTTP.
   - title: Log File Rotation Support
@@ -67,23 +67,20 @@ src="/asciinema/pretty-terminal.cast"
 :idleTimeLimit=3
 />
 
-### Add Metrics Support with Mixins
+### Add Wide Event Logging with Mixins
 
-Extend LogLayer with StatsD metrics support using the [Hot Shots Mixin](/mixins/hot-shots):
+Capture rich, self-contained log entries that span async boundaries. Use the [Wide Events Mixin](/mixins/wide-events) to accumulate data across your request:
 
 ```typescript
 import { LogLayer, useLogLayerMixin, ConsoleTransport } from 'loglayer';
-import { StatsD } from 'hot-shots';
-import { hotshotsMixin } from '@loglayer/mixin-hot-shots';
+import { AsyncLocalStorage } from 'async_hooks';
+import { createWideEventMixin } from '@loglayer/mixin-wide-events';
 
-// Create a StatsD client
-const statsd = new StatsD({
-  host: 'localhost',
-  port: 8125
-});
+// Set up async context for propagating wide event data
+const asyncLocalStorage = new AsyncLocalStorage<Record<string, any>>();
 
-// Register the mixin (must be called before creating LogLayer instances)
-useLogLayerMixin(hotshotsMixin(statsd));
+// Register the mixin (called before creating instances)
+useLogLayerMixin(createWideEventMixin({ asyncContext: asyncLocalStorage }));
 
 // Create LogLayer instance
 const log = new LogLayer({
@@ -92,13 +89,17 @@ const log = new LogLayer({
   })
 });
 
-// Use StatsD methods through the stats property
-log.stats.increment('request.count').send();
-log.info('Request received');
-log.stats.timing('request.duration', 150).send();
-log.info('Request processed');
-log.stats.gauge('active.connections', 42).send();
-log.info('Connection established');
+// Accumulate data across async boundaries
+asyncLocalStorage.run({}, () => {
+  log.withWideEvents({ userId: '123', ip: '10.0.0.1' });
+  log.info('User logged in');
+
+  log.withWideEvents({ action: 'view' });
+  log.info('User performed action');
+
+  // Emit the accumulated wide event as a single log entry
+  log.emitWideEvent({ message: 'Request completed' });
+});
 ```
 
 <!--@include: ./transports/_partials/transport-list.md-->

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -89,20 +89,6 @@ getLogger().withWideEvents({ orderId: "456" });
 getLogger().emitWideEvent({ message: "Order processed" });
 ```
 
-## API
-
-### `createWideEventMixin(options)`
-
-Creates a wide event mixin that can be registered with LogLayer.
-
-```typescript
-import { createWideEventMixin } from "@loglayer/mixin-wide-events";
-
-const mixin = createWideEventMixin({
-  asyncContext: new AsyncLocalStorage(),
-});
-```
-
 ## Configuration Options
 
 ### Required Parameters
@@ -119,6 +105,21 @@ const mixin = createWideEventMixin({
 | `wideEventField` | `string` | `undefined` | Field name to nest all wide event data under. When undefined, data is flattened at root level. |
 | `errorField` | `string` | `error`/`errors` | Field name for error data. `error` in single mode, `errors` in array mode. |
 | `errorsAsArray` | `boolean` | `false` | When true, errors are collected as an array. Each call to `withWideEventError()` appends. |
+| `sampling` | `WideEventSamplingConfig` | `undefined` | Sampling configuration to drop wide events at the configured rate. See [Sampling](#sampling) below. |
+
+## API
+
+### `createWideEventMixin(options)`
+
+Creates a wide event mixin that can be registered with LogLayer.
+
+```typescript
+import { createWideEventMixin } from "@loglayer/mixin-wide-events";
+
+const mixin = createWideEventMixin({
+  asyncContext: new AsyncLocalStorage(),
+});
+```
 
 ### `withWideEvents(data)`
 
@@ -358,7 +359,117 @@ res.on("finish", () => {
 });
 ```
 
-## Complete Example
+## Sampling
+
+Wide event sampling lets you randomly drop wide event emissions to control log volume and cost.
+"error" and "fatal" levels are **always kept** (100% sampled) — they are excluded from sampling
+regardless of the configured rate.
+
+### Quick Start
+
+```typescript
+// Keep ~10% of wide events (errors and fatals always kept)
+const mixin = createWideEventMixin({
+  asyncContext,
+  sampling: {
+    strategy: "default",
+    rate: 0.1,
+  },
+});
+```
+
+### Sampling Strategies
+
+#### `default` — single rate
+
+A single rate applies to all non-error/fatal levels.
+
+```typescript
+const mixin = createWideEventMixin({
+  asyncContext,
+  sampling: {
+    strategy: "default",
+    rate: 0.1,  // ~10% of info/warn/debug/trace events kept
+  },
+});
+```
+
+When `rate` is `1` (or `true`), all events are kept (sampling disabled).
+When `rate` is `0` (or `false`), all sample-able events are dropped.
+
+| Rate | Behaviour |
+|------|-----------|
+| `1` / `true` | Keep 100% (sampling off) |
+| `0.1` | ~10% of sample-able events kept |
+| `0` / `false` | Drop 100% of sample-able events |
+
+#### `per_level` — per-level rates
+
+Set independent rates per log level. Levels not in the map are kept at 100%.
+
+```typescript
+const mixin = createWideEventMixin({
+  asyncContext,
+  sampling: {
+    strategy: "per_level",
+    perLevel: {
+      trace: 0.01,  // keep 1% of trace
+      debug: 0.1,   // keep 10% of debug
+      info: 0.5,    // keep 50% of info
+    },
+  },
+});
+// warn, error, fatal are kept at 100% automatically
+```
+
+The `perLevel` map is **snapshotted at construction time** — mutating the object after
+calling `createWideEventMixin()` has no effect.
+
+### Sampling Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `strategy` | `"default"` \| `"per_level"` | `"default"` | How sampling rates are applied. |
+| `rate` | `boolean` \| `number` | `1` | Single rate for `default` strategy. |
+| `perLevel` | `Partial<Record<LogLevelType, boolean \| number>>` | `undefined` | Per-level rates for `per_level` strategy. |
+| `shouldEmit` | `(params: { wideData, level }) => boolean` | `undefined` | Custom callback that receives the accumulated wide event data and log level. Error/fatal levels always bypass this callback. |
+| `emitLevel` | `LogLevelType` | `undefined` | Override the default emit level when no explicit `level` is passed to `emitWideEvent()`. |
+
+### Custom Sampling Function
+
+The `shouldEmit` callback lets you inspect the full wide event data before deciding whether to emit:
+
+```typescript
+const mixin = createWideEventMixin({
+  asyncContext,
+  sampling: {
+    shouldEmit: ({ wideData, level }) => {
+      // Only emit events that have a userId
+      return !!wideData.userId;
+    },
+  },
+});
+```
+
+You can compose the callback with rate-based sampling — both checks must pass:
+
+```typescript
+const mixin = createWideEventMixin({
+  asyncContext,
+  sampling: {
+    strategy: "default",
+    rate: 0.5, // first pass: ~50% kept randomly
+    shouldEmit: ({ wideData }) => wideData.priority !== "low", // second pass: filter by content
+  },
+});
+```
+
+**Note:** "error" and "fatal" levels always bypass `shouldEmit` — they are emitted regardless of what the callback returns.
+
+### What Gets Sampled
+
+Sampling only applies to `emitWideEvent()` calls. Normal log calls (`logger.info()`, etc.)
+are unaffected.
 
 Here's a complete Express middleware example:
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -1363,6 +1363,7 @@ useLogLayerMixin({ mixinsToAdd: [metricsMixin] })
 
 ## Available Mixins
 
+- `@loglayer/mixin-wide-events` - Accumulate telemetry across async boundaries and emit as a single log entry (canonical log line). Supports configurable sampling (`rate` or `perLevel`) with `error`/`fatal` always kept at 100%.
 - `@loglayer/mixin-hot-shots` - Hot-Shots (StatsD) metrics
 
 ## Available Context Managers

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -327,7 +327,9 @@ Other: HTTP, Log File Rotation, OpenTelemetry
 - [Context Managers](https://loglayer.dev/context-managers/): Customize context inheritance behavior
 - [Log Level Managers](https://loglayer.dev/log-level-managers/): Customize log level behavior
 - [Mixins](https://loglayer.dev/mixins/): Extend LogLayer with custom methods
-  - [Wide Events](https://loglayer.dev/mixins/wide-events): Comprehensive, self-contained log entries
+  - [Wide Events](https://loglayer.dev/mixins/wide-events): Accumulate data across async boundaries and emit as single log entry; supports configurable sampling (default/per-level) with error/fatal always kept at 100%
+  - [Hot-Shots](https://loglayer.dev/mixins/hot-shots): Emit StatsD/dogstatsd metrics from log entries
+  - [Datadog HTTP Metrics](https://loglayer.dev/mixins/datadog-http-metrics): Send metrics to Datadog HTTP endpoint
 - [ElysiaJS Integration](https://loglayer.dev/integrations/elysia): ElysiaJS plugin with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
 - [Express Integration](https://loglayer.dev/integrations/express): Express middleware with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
 - [Fastify Integration](https://loglayer.dev/integrations/fastify): Fastify integration with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
@@ -335,3 +337,8 @@ Other: HTTP, Log File Rotation, OpenTelemetry
 - [Koa Integration](https://loglayer.dev/integrations/koa): Koa middleware with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
 - [Next.js Integration](https://loglayer.dev/example-integrations/nextjs): Next.js example
 - [Async Context Tracking](https://loglayer.dev/example-integrations/async-context): AsyncLocalStorage example
+  - [Wide Events](https://loglayer.dev/mixins/wide-events): Comprehensive, self-contained log entries with async context tracking and sampling
+  - [Hot-Shots](https://loglayer.dev/mixins/hot-shots): StatsD metrics
+  - [Datadog Metrics](https://loglayer.dev/mixins/datadog-http-metrics): Datadog HTTP metrics
+  - [Creating Mixins](https://loglayer.dev/mixins/creating-mixins): Build custom mixins
+  - [Testing Mixins](https://loglayer.dev/mixins/testing-mixins): Test custom mixins

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -7,6 +7,33 @@ description: Learn about the latest features and improvements in LogLayer
 
 - [`loglayer` Changelog](/core-changelogs/loglayer-changelog)
 
+## May 28, 2026
+
+`@loglayer/mixin-wide-events`:
+
+- **Sampling support**: The mixin can now randomly drop wide event emissions to control log volume and cost, with `"error"` and `"fatal"` levels always kept. Custom `shouldEmit` callbacks can filter by inspecting accumulated wide event data:
+
+```typescript
+// Rate-based sampling
+createWideEventMixin({
+  asyncContext,
+  sampling: {
+    strategy: "default",    // default | per_level
+    rate: 0.1,              // ~10% kept (error/fatal always 100%)
+  },
+});
+
+// Custom callback — filter by event contents
+createWideEventMixin({
+  asyncContext,
+  sampling: {
+    shouldEmit: ({ wideData, level }) => wideData.important === true,
+  },
+});
+```
+
+See the [Wide Events Mixin documentation](/mixins/wide-events#sampling) for details.
+
 ## May 25, 2026
 
 `loglayer`:

--- a/packages/mixins/wide-events/src/__tests__/sampling.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/sampling.test.ts
@@ -1,0 +1,621 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { BlankTransport, LogLayer, useLogLayerMixin } from "loglayer";
+import { describe, expect, it } from "vitest";
+import { createWideEventMixin } from "../index.js";
+
+describe("WideEventMixin - Sampling", () => {
+  let asyncContext: AsyncLocalStorage<Record<string, any>>;
+  let emittedLogs: any[];
+
+  function createLog(samplingConfig?: any) {
+    asyncContext = new AsyncLocalStorage();
+    emittedLogs = [];
+
+    const transport = new BlankTransport({
+      shipToLogger: (params) => {
+        emittedLogs.push({
+          level: params.logLevel,
+          messages: params.messages,
+          metadata: params.metadata,
+        });
+        return params.messages;
+      },
+    });
+
+    const mixin = createWideEventMixin({
+      asyncContext,
+      sampling: samplingConfig,
+    });
+    useLogLayerMixin(mixin);
+
+    return new LogLayer({ transport });
+  }
+
+  // Isolated helper for tests that need their own capture array
+  function createLogWithCapture(captureConfig: any): {
+    log: LogLayer;
+    ctx: AsyncLocalStorage<Record<string, any>>;
+    logs: any[];
+  } {
+    const ctx = new AsyncLocalStorage();
+    const logs: any[] = [];
+
+    const transport = new BlankTransport({
+      shipToLogger: (params) => {
+        logs.push({
+          level: params.logLevel,
+          messages: params.messages,
+          metadata: params.metadata,
+        });
+        return params.messages;
+      },
+    });
+
+    const mixin = createWideEventMixin({
+      asyncContext: ctx,
+      includeContext: captureConfig.includeContext ?? true,
+      sampling: {
+        strategy: captureConfig.strategy,
+        rate: captureConfig.rate,
+        perLevel: captureConfig.perLevel,
+        emitLevel: captureConfig.emitLevel,
+        shouldEmit: captureConfig.shouldEmit,
+      },
+    });
+    useLogLayerMixin(mixin);
+
+    return { log: new LogLayer({ transport }), ctx, logs };
+  }
+
+  describe("no sampling (default)", () => {
+    it("should keep all wide events when sampling is not configured", () => {
+      const log = createLog();
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "event 1" });
+        logger.emitWideEvent({ message: "event 2" });
+        logger.emitWideEvent({ message: "event 3" });
+      });
+
+      expect(emittedLogs).toHaveLength(3);
+    });
+  });
+
+  describe("default strategy", () => {
+    it("should keep all events when rate is 1", () => {
+      const log = createLog({ strategy: "default", rate: 1 });
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        for (let i = 0; i < 100; i++) {
+          logger.emitWideEvent({ message: `test-${i}` });
+        }
+      });
+
+      expect(emittedLogs).toHaveLength(100);
+    });
+
+    it("should drop all sample-able events when rate is 0", () => {
+      const log = createLog({ strategy: "default", rate: 0 });
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "trace", level: "trace" });
+        logger.emitWideEvent({ message: "debug", level: "debug" });
+        logger.emitWideEvent({ message: "info", level: "info" });
+        logger.emitWideEvent({ message: "warn", level: "warn" });
+      });
+
+      expect(emittedLogs).toHaveLength(0);
+    });
+
+    it("should always keep error level regardless of rate=0", () => {
+      const log = createLog({ strategy: "default", rate: 0 });
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "error", level: "error" });
+      });
+
+      expect(emittedLogs).toHaveLength(1);
+      expect(emittedLogs[0].level).toBe("error");
+    });
+
+    it("should always keep fatal level regardless of rate=0", () => {
+      const log = createLog({ strategy: "default", rate: 0 });
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "fatal", level: "fatal" });
+      });
+
+      expect(emittedLogs).toHaveLength(1);
+      expect(emittedLogs[0].level).toBe("fatal");
+    });
+
+    it("should sample at approximately the configured rate (0.1)", () => {
+      const log = createLog({ strategy: "default", rate: 0.1 });
+      const n = 5000;
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        for (let i = 0; i < n; i++) {
+          logger.emitWideEvent({ message: `test-${i}` });
+        }
+      });
+
+      const rate = emittedLogs.length / n;
+      // With 5000 samples, 0.1 rate, σ ≈ 0.0095
+      // ±3σ = ±0.0285 is permissive enough to avoid flakes
+      expect(rate).toBeGreaterThan(0.07);
+      expect(rate).toBeLessThan(0.13);
+    });
+
+    it("should accept boolean rate (true = keep all)", () => {
+      const log = createLog({ strategy: "default", rate: true });
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        for (let i = 0; i < 10; i++) {
+          logger.emitWideEvent({ message: `test-${i}` });
+        }
+      });
+
+      expect(emittedLogs).toHaveLength(10);
+    });
+
+    it("should accept boolean rate (false = drop all for sample-able levels)", () => {
+      const log = createLog({ strategy: "default", rate: false });
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "info", level: "info" });
+        logger.emitWideEvent({ message: "error", level: "error" });
+      });
+
+      expect(emittedLogs).toHaveLength(1);
+      expect(emittedLogs[0].level).toBe("error");
+    });
+  });
+
+  describe("per_level strategy", () => {
+    it("should apply per-level rates", () => {
+      const log = createLog({
+        strategy: "per_level",
+        perLevel: {
+          trace: 0, // drop all trace
+          debug: 1, // keep all debug
+          info: 0.5, // sample 50% of info
+        },
+      });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "trace-1", level: "trace" });
+        logger.emitWideEvent({ message: "trace-2", level: "trace" });
+        logger.emitWideEvent({ message: "debug-1", level: "debug" });
+        logger.emitWideEvent({ message: "error-1", level: "error" });
+        logger.emitWideEvent({ message: "fatal-1", level: "fatal" });
+        logger.emitWideEvent({ message: "warn-1", level: "warn" });
+      });
+
+      // Should have: debug-1, error-1, fatal-1, warn-1 (always kept + debug-1)
+      // warn is kept because it's not in the map (defaults to 100%)
+      const kept = emittedLogs.map((l) => l.messages[0]);
+      expect(kept).toContain("debug-1");
+      expect(kept).toContain("error-1");
+      expect(kept).toContain("fatal-1");
+      expect(kept).toContain("warn-1");
+
+      // trace should be dropped
+      expect(kept).not.toContain("trace-1");
+      expect(kept).not.toContain("trace-2");
+    });
+
+    it("should allow ~50% sampling on a single level", () => {
+      const log = createLog({
+        strategy: "per_level",
+        perLevel: {
+          info: 0.5,
+        },
+      });
+
+      const n = 1000;
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        for (let i = 0; i < n; i++) {
+          logger.emitWideEvent({ message: `info-${i}`, level: "info" });
+        }
+      });
+
+      const rate = emittedLogs.length / n;
+      expect(rate).toBeGreaterThan(0.4);
+      expect(rate).toBeLessThan(0.6);
+    });
+
+    it("should keep levels not in the perLevel map at 100%", () => {
+      const log = createLog({
+        strategy: "per_level",
+        perLevel: {
+          trace: 0, // only trace is explicitly set
+        },
+      });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "info", level: "info" });
+        logger.emitWideEvent({ message: "debug", level: "debug" });
+      });
+
+      expect(emittedLogs).toHaveLength(2);
+    });
+
+    it("should not use rate as fallback for unmapped levels in per_level", () => {
+      // Even with rate: 0, unmapped levels should still be kept at 100%
+      const log = createLog({
+        strategy: "per_level",
+        rate: 0, // this only matters for default strategy
+        perLevel: {
+          trace: 0,
+        },
+      });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        // info is not in perLevel, should be kept at 100%
+        logger.emitWideEvent({ message: "info", level: "info" });
+      });
+
+      expect(emittedLogs).toHaveLength(1);
+      expect(emittedLogs[0].level).toBe("info");
+    });
+
+    it("should ignore error/fatal in perLevel map", () => {
+      const log = createLog({
+        strategy: "per_level",
+        perLevel: {
+          trace: 1,
+          error: 0, // should be ignored — always kept
+          fatal: 0, // should be ignored — always kept
+        },
+      });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "error", level: "error" });
+        logger.emitWideEvent({ message: "fatal", level: "fatal" });
+      });
+
+      expect(emittedLogs).toHaveLength(2);
+    });
+
+    it("should snapshot the perLevel map at construction time", () => {
+      const perLevel = { info: 0 };
+      const log = createLog({ strategy: "per_level", perLevel });
+
+      // Mutate the map after construction — should have no effect
+      perLevel.info = 1;
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        for (let i = 0; i < 100; i++) {
+          logger.emitWideEvent({ message: `info-${i}`, level: "info" });
+        }
+      });
+
+      // info was sampled at rate=0 at construction time
+      expect(emittedLogs).toHaveLength(0);
+    });
+  });
+
+  describe("emitLevel option", () => {
+    it("should use emitLevel as default when no level provided", () => {
+      const log = createLog({ strategy: "default", rate: 1, emitLevel: "debug" });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        // No level provided — should use emitLevel
+        logger.emitWideEvent({ message: "test" });
+      });
+
+      expect(emittedLogs[0].level).toBe("debug");
+    });
+
+    it("should respect explicit level over emitLevel", () => {
+      const log = createLog({ strategy: "default", rate: 1, emitLevel: "debug" });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "test", level: "error" });
+      });
+
+      expect(emittedLogs[0].level).toBe("error");
+    });
+  });
+
+  describe("mixed usage", () => {
+    it("should only sample wide events, not normal log calls", () => {
+      const log = createLog({ strategy: "default", rate: 0 });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        // Normal log should still go through
+        logger.info("normal info log");
+        // Wide event should be dropped
+        logger.emitWideEvent({ message: "wide event" });
+        // Error wide event should pass through
+        logger.emitWideEvent({ message: "wide error", level: "error" });
+      });
+
+      // Should have the normal info log and the wide error, but not the dropped wide event
+      expect(emittedLogs).toHaveLength(2);
+      expect(emittedLogs[0].level).toBe("info");
+      expect(emittedLogs[1].level).toBe("error");
+    });
+
+    it("should work with withContext", () => {
+      const log = createLog({ strategy: "default", rate: 1 });
+
+      asyncContext.run({}, () => {
+        const logger = log.child().withContext({ requestId: "req-1" });
+        logger.withWideEvents({ userId: "123" });
+        logger.emitWideEvent({ message: "test" });
+      });
+
+      expect(emittedLogs).toHaveLength(1);
+      expect(emittedLogs[0].metadata).toEqual({ userId: "123" });
+      expect(emittedLogs[0].level).toBe("info");
+    });
+  });
+
+  describe("shouldEmit callback", () => {
+    it("should receive wideData and level", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        shouldEmit: ({ wideData: _wideData, level: _level }) => true,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ userId: "123", action: "login" });
+        logger.emitWideEvent({ message: "test", level: "debug" });
+      });
+
+      expect(logs).toHaveLength(1);
+      // Note: shouldEmit receives the wideData, which we can verify via caption
+      expect(logs[0].level).toBe("debug");
+    });
+
+    it("should drop the event when callback returns false", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        shouldEmit: ({ wideData }) => !!wideData.includeMe,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ userId: "123" });
+        logger.emitWideEvent({ message: "dropped" });
+      });
+
+      expect(logs).toHaveLength(0);
+    });
+
+    it("should keep the event when callback returns true", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        shouldEmit: ({ wideData }) => !!wideData.keepMe,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ keepMe: true });
+        logger.emitWideEvent({ message: "kept" });
+      });
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("info");
+    });
+
+    it("should always keep error/fatal regardless of callback", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        shouldEmit: () => false, // always drop
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "error", level: "error" });
+        logger.emitWideEvent({ message: "fatal", level: "fatal" });
+        logger.emitWideEvent({ message: "info", level: "info" });
+      });
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0].level).toBe("error");
+      expect(logs[1].level).toBe("fatal");
+    });
+
+    it("should compose with rate sampling (both checks must pass)", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 0, // drop all non-error/fatal
+        shouldEmit: ({ wideData }) => !!wideData.keepMe, // would keep
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ keepMe: true });
+        logger.emitWideEvent({ message: "dropped-by-rate" });
+      });
+
+      expect(logs).toHaveLength(0);
+    });
+
+    it("should still filter via callback when rate check passes", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 1, // keep all non-error/fatal
+        shouldEmit: ({ wideData }) => !!wideData.secret,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ noSecret: true });
+        logger.emitWideEvent({ message: "dropped-by-callback" });
+      });
+
+      // Rate passes but callback returns false -> dropped
+      expect(logs).toHaveLength(0);
+    });
+
+    it("should work with per_level strategy and shouldEmit", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "per_level",
+        perLevel: {
+          trace: 1, // keep trace, drop everything else
+        },
+        shouldEmit: ({ wideData }) => !!wideData.keepMe,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+
+        logger.withWideEvents({ keepMe: true });
+        logger.emitWideEvent({ message: "trace-kept", level: "trace" });
+
+        logger.clearWideEvents();
+
+        // info level: not in perLevel, rate=1 (unmapped levels keep)
+        // but callback says !keepMe -> false -> dropped
+        logger.withWideEvents({ keepMe: false });
+        logger.emitWideEvent({ message: "info-dropped", level: "info" });
+      });
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("trace");
+    });
+
+    it("should keep event when shouldEmit callback throws (fail-open)", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        shouldEmit: () => {
+          throw new Error("oops");
+        },
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "kept-despite-throw" });
+      });
+
+      // Callback threw — event is kept (fail-open)
+      expect(logs).toHaveLength(1);
+    });
+
+    it("should keep error/fatal when shouldEmit throws", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        shouldEmit: () => {
+          throw new Error("oops");
+        },
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "error", level: "error" });
+        logger.emitWideEvent({ message: "info", level: "info" });
+      });
+
+      // Both kept — error exempt, info kept due to fail-open
+      expect(logs).toHaveLength(2);
+    });
+  });
+
+  describe("rate clamping", () => {
+    it("should clamp rate > 1 to 1 (keep all)", () => {
+      const log = createLog({ strategy: "default", rate: 1.5 });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        for (let i = 0; i < 100; i++) {
+          logger.emitWideEvent({ message: `test-${i}` });
+        }
+      });
+
+      expect(emittedLogs).toHaveLength(100);
+    });
+
+    it("should clamp rate < 0 to 0 (drop all for sample-able levels)", () => {
+      const log = createLog({ strategy: "default", rate: -0.5 });
+
+      asyncContext.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "info", level: "info" });
+        logger.emitWideEvent({ message: "error", level: "error" });
+      });
+
+      // info dropped (rate clamped to 0), error always kept
+      expect(emittedLogs).toHaveLength(1);
+      expect(emittedLogs[0].level).toBe("error");
+    });
+
+    it("should keep error/fatal when only shouldEmit throws", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "per_level",
+        perLevel: { trace: 1, error: 0, fatal: 0 },
+        shouldEmit: () => {
+          throw new Error("oops");
+        },
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "trace", level: "trace" });
+        logger.emitWideEvent({ message: "error", level: "error" });
+        logger.emitWideEvent({ message: "fatal", level: "fatal" });
+      });
+
+      // All kept: error/fatal exempt from everything, trace via fail-open
+      expect(logs).toHaveLength(3);
+    });
+
+    it("emitLevel feeds into per_level rate bucket", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "per_level",
+        perLevel: { debug: 0 }, // drop all debug
+        emitLevel: "debug",
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        // No explicit level — uses emitLevel "debug", rate for debug is 0
+        logger.emitWideEvent({ message: "dropped" });
+      });
+
+      expect(logs).toHaveLength(0);
+    });
+
+    it("shouldEmit receives level from emitLevel", () => {
+      const receivedLevels: string[] = [];
+      const { log, ctx } = createLogWithCapture({
+        strategy: "default",
+        rate: 1,
+        emitLevel: "warn",
+        shouldEmit: ({ level }) => {
+          receivedLevels.push(level);
+          return true;
+        },
+      });
+
+      ctx.run({}, () => {
+        log.child().emitWideEvent({ message: "test" });
+      });
+
+      expect(receivedLevels).toEqual(["warn"]);
+    });
+
+    it("explicit level overrides emitLevel for sampling", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "per_level",
+        perLevel: { info: 0 },
+        emitLevel: "debug", // would not be sampled
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        // Explicit "info" overrides emitLevel "debug", rate=0 drops it
+        logger.emitWideEvent({ message: "dropped", level: "info" });
+      });
+
+      expect(logs).toHaveLength(0);
+    });
+  });
+});

--- a/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
@@ -9,7 +9,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { ILogLayer } from "loglayer";
 import { LogLayer, useLogLayerMixin } from "loglayer";
 import { describe, expectTypeOf, it } from "vitest";
-import { createWideEventMixin } from "../index.js";
+import { createWideEventMixin, type WideEventSamplingConfig, type WideEventSamplingStrategy } from "../index.js";
 
 describe("Type Tests", () => {
   // Setup mixin once for all tests (matching docs pattern)
@@ -85,5 +85,46 @@ describe("Type Tests", () => {
     // All config options should be valid
     logger.emitWideEvent({ message: "msg" });
     logger.emitWideEvent({ message: "msg", level: "error" });
+  });
+
+  it("should accept sampling config in mixin options", () => {
+    // default strategy
+    const config1: WideEventSamplingConfig = {
+      strategy: "default",
+      rate: 0.5,
+    };
+
+    const asyncContext = new AsyncLocalStorage<Record<string, any>>();
+    createWideEventMixin({ asyncContext: asyncContext, sampling: config1 });
+
+    // per_level strategy
+    const config2: WideEventSamplingConfig = {
+      strategy: "per_level",
+      perLevel: {
+        trace: 0,
+        debug: 0.1,
+        info: 0.5,
+        error: 1, // ignored — but type-accepted
+      },
+    };
+
+    createWideEventMixin({ asyncContext: new AsyncLocalStorage(), sampling: config2 });
+
+    // boolean rate
+    const config3: WideEventSamplingConfig = {
+      rate: true,
+    };
+    createWideEventMixin({ asyncContext: new AsyncLocalStorage(), sampling: config3 });
+
+    // emitLevel
+    const config4: WideEventSamplingConfig = {
+      strategy: "default",
+      rate: 1,
+      emitLevel: "debug",
+    };
+    createWideEventMixin({ asyncContext: new AsyncLocalStorage(), sampling: config4 });
+
+    // Type check: strategy is literal
+    expectTypeOf<WideEventSamplingStrategy>().toEqualTypeOf<"default" | "per_level">();
   });
 });

--- a/packages/mixins/wide-events/src/index.ts
+++ b/packages/mixins/wide-events/src/index.ts
@@ -3,5 +3,8 @@ export type {
   EmitWideEventConfig,
   IWideEventMixin,
   WideEventMixinOptions,
+  WideEventSamplingConfig,
+  WideEventSamplingParams,
+  WideEventSamplingStrategy,
 } from "./types.js";
 import "./types.js"; // Import types to ensure declarations are processed

--- a/packages/mixins/wide-events/src/mixin.ts
+++ b/packages/mixins/wide-events/src/mixin.ts
@@ -5,7 +5,52 @@ import {
   type LogLayerMixinRegistration,
   type LogLayerPlugin,
 } from "loglayer";
-import type { EmitWideEventConfig, WideEventMixinOptions } from "./types.js";
+import type { EmitWideEventConfig, WideEventMixinOptions, WideEventSamplingConfig } from "./types.js";
+
+/**
+ * Log levels that are never sampled — always kept at 100%.
+ */
+const EXEMPT_LEVELS = new Set(["error", "fatal"]);
+
+/**
+ * Normalize a boolean or numeric rate to a number in [0, 1].
+ * `true` becomes 1, `false` becomes 0, numbers are clamped to [0, 1].
+ * `NaN`, `Infinity`, and `-Infinity` are treated as 0 (drop all).
+ */
+function toRate(value: boolean | number | undefined): number {
+  if (value === undefined) return 1;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+/**
+ * Run rate-based sampling (default or per_level strategy).
+ * Returns true if the rate check passes, false if dropped.
+ * Always returns true for error/fatal levels.
+ */
+function runRateSampling(
+  level: string,
+  strategy: "default" | "per_level" | undefined,
+  rate: boolean | number | undefined,
+  perLevel?: Partial<Record<string, boolean | number>>,
+): boolean {
+  if (EXEMPT_LEVELS.has(level)) {
+    return true;
+  }
+
+  if (strategy === "per_level" && perLevel) {
+    const perRate = toRate(perLevel[level]);
+    if (perRate === 1) return true;
+    if (perRate === 0) return false;
+    return Math.random() < perRate;
+  }
+
+  const r = toRate(rate);
+  if (r === 1) return true;
+  if (r === 0) return false;
+  return Math.random() < r;
+}
 
 /**
  * Creates a LogLayer mixin that adds wide event logging functionality.
@@ -19,7 +64,6 @@ import type { EmitWideEventConfig, WideEventMixinOptions } from "./types.js";
  *   wide event data across async boundaries. For Node.js, use `new AsyncLocalStorage()`
  *   from `async_hooks`. For browser environments, provide your own compatible implementation.
  * @param options.includeContext - Whether to include withContext() data in emitted wide events (default: true)
-
  *
  * @returns A LogLayer mixin registration object
  *
@@ -58,6 +102,18 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
   const errorsAsArray = options.errorsAsArray ?? false;
   // Default error field: "errors" for arrays, "error" for single
   const errorField = options.errorField ?? (errorsAsArray ? "errors" : "error");
+
+  // Snapshot perLevel map at construction time
+  const snapshotPerLevel = options.sampling?.perLevel ? { ...options.sampling.perLevel } : undefined;
+  const samplingConfig: WideEventSamplingConfig | undefined = options.sampling
+    ? {
+        strategy: options.sampling.strategy ?? "default",
+        rate: options.sampling.rate,
+        perLevel: snapshotPerLevel,
+        emitLevel: options.sampling.emitLevel,
+        shouldEmit: options.sampling.shouldEmit,
+      }
+    : undefined;
 
   // Default error serializer - used if LogLayer has no errorSerializer configured
   function defaultErrorSerializer(err: any): Record<string, any> {
@@ -227,6 +283,19 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
    * Implementation for emitWideEvent
    */
   function emitWideEventImpl(config: EmitWideEventConfig, self: any): void {
+    // Determine log level
+    const defaultLevel = samplingConfig?.emitLevel ?? "info";
+    const level = config.level ?? defaultLevel;
+
+    // Check non-callback rate sampling early (skip data building when possible)
+    if (
+      samplingConfig &&
+      !samplingConfig.shouldEmit &&
+      !runRateSampling(level, samplingConfig.strategy, samplingConfig.rate, samplingConfig.perLevel)
+    ) {
+      return;
+    }
+
     const store = asyncContext.getStore();
 
     // Build wide event data with priority order
@@ -243,8 +312,29 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
       Object.assign(wideEventData, store._llWideEvents);
     }
 
-    // Determine log level
-    const level = config.level ?? "info";
+    // Run custom callback sampling (now that data is available)
+    if (samplingConfig?.shouldEmit) {
+      // error/fatal are always kept — skip callback entirely
+      if (!EXEMPT_LEVELS.has(level)) {
+        // Run rate sampling if not already done
+        const ratePassed = runRateSampling(
+          level,
+          samplingConfig.strategy,
+          samplingConfig.rate,
+          samplingConfig.perLevel,
+        );
+        // Fail-open: if callback throws, keep the event
+        let callbackOk = true;
+        try {
+          callbackOk = samplingConfig.shouldEmit({ wideData: wideEventData, level });
+        } catch {
+          // Callback threw — keep the event
+        }
+        if (!ratePassed || !callbackOk) {
+          return;
+        }
+      }
+    }
 
     // Wrap in field if configured, otherwise use flat
     const metadataToEmit = wideEventField ? { [wideEventField]: wideEventData } : wideEventData;

--- a/packages/mixins/wide-events/src/types.ts
+++ b/packages/mixins/wide-events/src/types.ts
@@ -2,6 +2,129 @@ import type { AsyncLocalStorage } from "node:async_hooks";
 import type { LogLevelType } from "loglayer";
 
 /**
+ * Parameters passed to a custom `shouldEmit` sampling callback.
+ * Provides the accumulated wide event data and the log level so the
+ * callback can make an informed keep/drop decision.
+ */
+export interface WideEventSamplingParams {
+  /**
+   * The accumulated wide event data (wide events + optional context).
+   * Contains the merged data that would be emitted if kept.
+   */
+  wideData: Record<string, any>;
+
+  /**
+   * The log level that would be used for the emission.
+   */
+  level: LogLevelType;
+}
+
+/**
+ * Sampling strategy for wide events.
+ *
+ * - `"default"` — a single `rate` applies to all non-error levels.
+ * - `"per_level"` — per-level rates keyed by LogLevelType; levels not in the
+ *   map are kept unconditionally.
+ */
+export type WideEventSamplingStrategy = "default" | "per_level";
+
+/**
+ * Configuration for sampling wide event emissions.
+ *
+ * "error" and "fatal" levels are always kept (100% sampled) regardless of
+ * the configured rate.
+ */
+export interface WideEventSamplingConfig {
+  /**
+   * The sampling strategy.
+   *
+   * - `"default"` — a single `rate` applies to all non-error levels.
+   * - `"per_level"` — per-level rates from the `perLevel` map; levels not in
+   *   the map are kept at 100%.
+   *
+   * @default "default"
+   */
+  strategy?: WideEventSamplingStrategy;
+
+  /**
+   * A rate between 0 and 1 that determines the fraction of events to keep.
+   *
+   * - `1` (or `true`) — keep 100% (sampling disabled)
+   * - `0.1` — ~10% of events kept
+   * - `0` (or `false`) — keep 0% (all dropped for sample-able levels)
+   *
+   * With `"default"` strategy this rate applies to all non-error/fatal levels.
+   * With `"per_level"` strategy this field is **ignored** — unmapped levels
+   * default to a fill for levels not present
+   * in the `perLevel` map.
+   *
+   * @default 1
+   */
+  rate?: boolean | number;
+
+  /**
+   * Per-level sampling rates when strategy is `"per_level"`.
+   * Keys are log level strings (e.g. `"trace"`, `"info"`, `"warn"`).
+   * Levels not listed are kept at 100%.
+   *
+   * **Important:** "error" and "fatal" are always kept (100%) — values
+   * for those keys are silently ignored.
+   *
+   * The map is snapshotted at construction time; mutating it afterward has
+   * no effect.
+   *
+   * @example
+   * ```ts
+   * {
+   *   strategy: "per_level",
+   *   perLevel: {
+   *     trace: 0.1,
+   *     debug: 0.3,
+   *     info: 0.5,
+   *   },
+   * }
+   * // warn, error, fatal are all 100%
+   * ```
+   */
+  perLevel?: Partial<Record<LogLevelType, boolean | number>>;
+
+  /**
+   * A custom sampling callback that receives the wide event data and log
+   * level, allowing you to make an informed keep/drop decision.
+   *
+   * When provided, this callback is invoked **in addition to** the built-in
+   * rate-based sampling. An event is only kept when **both** the built-in
+   * check passes (if `rate`/`perLevel` are configured) **and** the callback
+   * returns `true`. If only `shouldEmit` is set (no `rate`), the callback
+   * acts as the sole gate.
+   *
+   * **Note:** "error" and "fatal" levels are always emitted regardless of
+   * what this callback returns.
+   *
+   * @example
+   * ```ts
+   * {
+   *   shouldEmit: ({ wideData, level }) => {
+   *     // Only emit wide events that have a userId
+   *     return !!wideData.userId;
+   *   },
+   * }
+   * ```
+   */
+  shouldEmit?: (params: WideEventSamplingParams) => boolean;
+
+  /**
+   * Override the default log level when no explicit `level` is passed to
+   * `emitWideEvent()`. When set, the resolved level uses this value instead
+   * of `"info"`. This **does** affect sampling decisions — with `per_level`
+   * strategy, the level from `emitLevel` determines which rate bucket applies.
+   *
+   * @default undefined (falls back to `"info"`)
+   */
+  emitLevel?: LogLevelType;
+}
+
+/**
  * Configuration options for creating a wide event mixin.
  */
 export interface WideEventMixinOptions {
@@ -46,6 +169,22 @@ export interface WideEventMixinOptions {
    * @default false
    */
   errorsAsArray?: boolean;
+
+  /**
+   * Optional: Sampling configuration for wide events.
+   * When provided, the mixin will randomly decide whether to emit or skip wide
+   * events based on the configured rate(s).
+   *
+   * "error" and "fatal" levels are always emitted (100% sampled).
+   *
+   * @example
+   * // Keep ~10% of wide events (excluding errors/fatals)
+   * { sampling: { strategy: "default", rate: 0.1 } }
+   *
+   * // Per-level: keep all trace/debug, but sample info at 5%
+   * { sampling: { strategy: "per_level", perLevel: { info: 0.05 } } }
+   */
+  sampling?: WideEventSamplingConfig;
 }
 
 /**
@@ -170,14 +309,14 @@ export interface IWideEventMixin {
    * } catch (err) {
    *   // For single error (replaces previous)
    *   logger.withWideEventError(err);
-   *   
+   *
    *   // With errorsAsArray: true - errors accumulate
    *   logger.withWideEventError(err).withWideEventError(otherErr);
    * }
    * ```
    */
   withWideEventError(error: any): this;
-};
+}
 
 // Module augmentation for ILogLayer and ILogBuilder
 declare module "loglayer" {


### PR DESCRIPTION
Add configurable sampling to control wide event emission volume.

Features:
- Rate-based sampling with 'default' (single rate) and 'per_level' (per-level rates) strategies
- Custom shouldEmit callback receiving { wideData, level } for content-aware filtering
- error/fatal levels always exempt from all sampling (100% kept)
- PerLevel map snapshotted at construction to prevent mutation
- Rate clamping to [0,1], NaN/Infinity handled gracefully
- Fail-open: shouldEmit callback exceptions keep the event
- emitLevel override feeds into sampling decisions

Includes 73 tests, docs, LLM indexes, whats-new, cheatsheet, and changeset.