### PR TITLE
feat(mixin-wide-events): add forceKeep sampling override

### DIFF
--- a/.changeset/wide-events-force-keep.md
+++ b/.changeset/wide-events-force-keep.md
@@ -1,0 +1,5 @@
+---
+"@loglayer/mixin-wide-events": minor
+---
+
+Add `forceKeep` sampling override — a keep-only callback evaluated before the rate check that rescues wide events the configured rate would otherwise drop (e.g. always keep a request flagged for debugging or showing a downstream failure). Returns `true` to emit immediately, bypassing the rate check and `shouldEmit`; returns `false` to apply normal sampling; and fails safe on throw. Thrown `forceKeep`/`shouldEmit` callbacks are now logged via `console.error` when `consoleDebug` is enabled.

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ test-logs/
 live-logs/
 .npm-access-state.json
 docs/plans/
+docs/superpowers/

--- a/docs/src/cheatsheet.md
+++ b/docs/src/cheatsheet.md
@@ -392,5 +392,5 @@ See [Basic Logging](/logging-api/basic-logging#raw-logging) for context behavior
 | Raw log entry | `log.raw({ logLevel, messages, metadata, rootData })` | Single entry |
 | Flat emission | `rootData: { userId: 123 }` in `raw()` | Bypasses `metadataFieldName` nesting |
 | Mock for tests | `new MockLogLayer()` | - |
-| Wide events mixin | `@loglayer/mixin-wide-events` | Accumulate data across async boundaries and emit as single log entry (canonical log line). Supports sampling with `error`/`fatal` defaulting to 100% (overridable via `perLevel` or ``shouldEmit``). |
+| Wide events mixin | `@loglayer/mixin-wide-events` | Accumulate data across async boundaries and emit as single log entry (canonical log line). Sampling: `error`/`fatal` default to 100% (overridable via `perLevel`/`shouldEmit`); `forceKeep` can rescue rate-dropped events. |
 | Create wide event mixin | `createWideEventMixin({ asyncContext, sampling: { strategy: 'default', `rate`: 0.1 } })` | - |

--- a/docs/src/mixins/wide-events.md
+++ b/docs/src/mixins/wide-events.md
@@ -386,10 +386,11 @@ setting `perLevel` rates or using the `shouldEmit` callback.
 
 ### Evaluation Order
 
-1. **`shouldEmit` callback** (if set): Inspects `wideData` + `level`. Returns `true` → kept, `false` → dropped. Throws → kept (fail-open). **Then** runs `rate` check too — **BOTH must pass.**
-2. **`error`/`fatal` default to 100%**: Kept by default unless explicitly mapped in `perLevel`.
-3. **`per_level` strategy**: Checks `perLevel` map → unmapped → `rate`.
-4. **`default` strategy**: Uses `rate` for all non-error/fatal levels.
+1. **`forceKeep` callback** (if set): Inspects `wideData` + `level`. Returns `true` → **kept immediately**, bypassing the rate check and `shouldEmit`. Returns `false` → falls through to the checks below. Throws → **fail-safe**: falls through to the checks below (logged when `consoleDebug` is enabled). `forceKeep` is **keep-only** — it can rescue but never drop.
+2. **`shouldEmit` callback** (if set): Inspects `wideData` + `level`. Returns `true` → kept, `false` → dropped. Throws → kept (fail-open). **Then** runs `rate` check too — **BOTH must pass.**
+3. **`error`/`fatal` default to 100%**: Kept by default unless explicitly mapped in `perLevel`.
+4. **`per_level` strategy**: Checks `perLevel` map → unmapped → `rate`.
+5. **`default` strategy**: Uses `rate` for all non-error/fatal levels.
 
 ### Quick Start
 
@@ -459,6 +460,7 @@ calling `createWideEventMixin()` has no effect.
 | `rate` | `boolean` \| `number` | `1` | Single `rate` for `default` strategy; with `"per_level"` acts as fallback for unmapped levels. |
 | `perLevel` | `Partial<Record<LogLevelType, boolean \| number>>` | `undefined` | Per-level rates for `per_level` strategy. |
 | `shouldEmit` | `(params: { wideData, level }) => boolean` | `undefined` | Custom callback that receives the accumulated wide event data and log level. Can override the default error/fatal exemption by returning `false`. |
+| `forceKeep` | `(params: { wideData, level }) => boolean` | `undefined` | Keep-only override evaluated **before** `rate`/`shouldEmit`. Returns `true` → kept immediately (bypasses rate + `shouldEmit`); `false` → normal logic applies. Cannot drop events. Fails **safe** on throw (falls through to `rate`). |
 | `emitLevel` | `LogLevelType` | `undefined` | Override the default emit level when no explicit `level` is passed to `emitWideEvent()`. |
 
 ### Custom Sampling Function
@@ -491,6 +493,50 @@ const mixin = createWideEventMixin({
 ```
 
 **Note:** "error" and "fatal" default to a 100% keep `rate`, but can be overridden by returning `false` from `shouldEmit` or by explicitly setting their `rate` in `perLevel`.
+
+### Force-Keep Override
+
+`forceKeep` lets you **rescue** events the rate would otherwise drop — for
+example, sampling 2xx responses at 1% but always keeping requests flagged for
+debugging or showing a downstream failure:
+
+```typescript
+const mixin = createWideEventMixin({
+  asyncContext,
+  sampling: {
+    strategy: "per_level",
+    perLevel: { info: 0.01 }, // keep ~1% of info
+    forceKeep: ({ wideData }) =>
+      wideData.debug === true ||
+      (wideData.deps?.someService?.failures ?? 0) > 0,
+  },
+});
+```
+
+`forceKeep` only sees `wideData` and `level` — it cannot read the request,
+headers, or any external state. Write the signal into the wide event first:
+
+```typescript
+// e.g. in middleware, when a debug header is present
+if (req.headers["x-debug"]) {
+  logger.withWideEvents({ debug: true });
+}
+// ...later
+logger.emitWideEvent({ message: "request completed" }); // forceKeep sees wideData.debug
+```
+
+::: tip
+`forceKeep` is **keep-only**. Returning `false` never drops an event that would
+otherwise be kept — `error`/`fatal` still emit and `info` still runs the rate.
+Use `shouldEmit` (or `perLevel`) to drop events.
+:::
+
+::: warning
+`forceKeep` fails **safe**: if it throws, the throw is swallowed and force-keep
+is skipped for that event (normal `rate`/`shouldEmit` logic applies), so a broken
+override can't blow past your sampling budget. A throwing `forceKeep` or
+`shouldEmit` is logged via `console.error` only when `consoleDebug` is enabled.
+:::
 
 ### What Gets Sampled
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -1390,7 +1390,7 @@ useLogLayerMixin({ mixinsToAdd: [metricsMixin] })
 
 ## Available Mixins
 
-- `@loglayer/mixin-wide-events` - Accumulate telemetry across async boundaries and emit as a single log entry (canonical log line). Wide event data is always emitted flat at the root level, regardless of `metadataFieldName` configuration. Supports configurable sampling (`rate` or `perLevel`) with `error`/`fatal` defaulting to 100% (can be overridden).
+- `@loglayer/mixin-wide-events` - Accumulate telemetry across async boundaries and emit as a single log entry (canonical log line). Wide event data is always emitted flat at the root level, regardless of `metadataFieldName` configuration. Supports configurable sampling (`rate` or `perLevel`) with `error`/`fatal` defaulting to 100% (can be overridden), a `shouldEmit` restrictor callback, and a keep-only `forceKeep` override that rescues events the rate would drop (fails safe on throw).
 - `@loglayer/mixin-hot-shots` - Hot-Shots (StatsD) metrics
 
 ## Available Context Managers

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -366,7 +366,7 @@ Other: HTTP, Log File Rotation, OpenTelemetry
 - [Context Managers](https://loglayer.dev/context-managers/): Customize context inheritance behavior
 - [Log Level Managers](https://loglayer.dev/log-level-managers/): Customize log level behavior
 - [Mixins](https://loglayer.dev/mixins/): Extend LogLayer with custom methods
-  - [Wide Events](https://loglayer.dev/mixins/wide-events): Accumulate data across async boundaries and emit as single log entry; wide event data is always flat at root level (ignores metadataFieldName); supports configurable sampling (default/per-level) with error/fatal defaulting to 100% (can be overridden)
+  - [Wide Events](https://loglayer.dev/mixins/wide-events): Accumulate data across async boundaries and emit as single log entry; wide event data is always flat at root level (ignores metadataFieldName); supports configurable sampling (default/per-level) with error/fatal defaulting to 100% (can be overridden), plus a keep-only `forceKeep` override to rescue rate-dropped events
   - [Hot-Shots](https://loglayer.dev/mixins/hot-shots): Emit StatsD/dogstatsd metrics from log entries
   - [Datadog HTTP Metrics](https://loglayer.dev/mixins/datadog-http-metrics): Send metrics to Datadog HTTP endpoint
 - [ElysiaJS Integration](https://loglayer.dev/integrations/elysia): ElysiaJS plugin with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -7,6 +7,12 @@ description: Learn about the latest features and improvements in LogLayer
 
 - [`loglayer` Changelog](/core-changelogs/loglayer-changelog)
 
+## Jul 2, 2026
+
+`@loglayer/mixin-wide-events`:
+
+- **Added `forceKeep` sampling override**: a keep-only callback evaluated before the rate check that rescues events the configured rate would otherwise drop. Thrown `forceKeep`/`shouldEmit` callbacks are now logged when `consoleDebug` is enabled.
+
 `@loglayer/mixin-wide-events`, `@loglayer/mixin-hot-shots`, `@loglayer/mixin-datadog-http-metrics`:
 
 - **Fixed type resolution**: All mixin packages now declare `loglayer` as a peer dependency, ensuring tsdown externalizes `loglayer` types instead of bundling them inline. This fixes type incompatibility when using mixins with consumer projects that have their own `loglayer` installation.

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -13,6 +13,8 @@ description: Learn about the latest features and improvements in LogLayer
 
 - **Added `forceKeep` sampling override**: a keep-only callback evaluated before the rate check that rescues events the configured rate would otherwise drop. Thrown `forceKeep`/`shouldEmit` callbacks are now logged when `consoleDebug` is enabled.
 
+## May 30, 2026
+
 `@loglayer/mixin-wide-events`, `@loglayer/mixin-hot-shots`, `@loglayer/mixin-datadog-http-metrics`:
 
 - **Fixed type resolution**: All mixin packages now declare `loglayer` as a peer dependency, ensuring tsdown externalizes `loglayer` types instead of bundling them inline. This fixes type incompatibility when using mixins with consumer projects that have their own `loglayer` installation.

--- a/packages/mixins/wide-events/src/__tests__/sampling.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/sampling.test.ts
@@ -62,6 +62,7 @@ describe("WideEventMixin - Sampling", () => {
         perLevel: captureConfig.perLevel,
         emitLevel: captureConfig.emitLevel,
         shouldEmit: captureConfig.shouldEmit,
+        forceKeep: captureConfig.forceKeep,
       },
     });
     useLogLayerMixin(mixin);
@@ -616,6 +617,237 @@ describe("WideEventMixin - Sampling", () => {
       });
 
       expect(logs).toHaveLength(0);
+    });
+  });
+
+  describe("forceKeep", () => {
+    it("rescues an event the rate would drop", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 0, // would drop all info
+        forceKeep: ({ wideData }) => wideData.debug === true,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ debug: true });
+        logger.emitWideEvent({ message: "rescued", level: "info" });
+      });
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].messages[0]).toBe("rescued");
+    });
+
+    it("bypasses shouldEmit when forceKeep returns true", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        rate: 1,
+        shouldEmit: () => false, // would drop everything
+        forceKeep: ({ wideData }) => wideData.keep === true,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ keep: true });
+        logger.emitWideEvent({ message: "kept", level: "info" });
+      });
+
+      expect(logs).toHaveLength(1);
+    });
+
+    it("falls through to rate/shouldEmit when forceKeep returns false (drops at rate 0)", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 0,
+        forceKeep: () => false,
+      });
+
+      ctx.run({}, () => {
+        log.child().emitWideEvent({ message: "dropped", level: "info" });
+      });
+
+      expect(logs).toHaveLength(0);
+    });
+
+    it("falls through and keeps when forceKeep returns false and rate passes (fast-path disabled)", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 1,
+        forceKeep: () => false,
+      });
+
+      ctx.run({}, () => {
+        log.child().emitWideEvent({ message: "kept-by-rate", level: "info" });
+      });
+
+      expect(logs).toHaveLength(1);
+    });
+
+    it("does not interfere with error/fatal exemption when returning false", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 0,
+        forceKeep: () => false,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.emitWideEvent({ message: "err", level: "error" });
+        logger.emitWideEvent({ message: "fat", level: "fatal" });
+      });
+
+      expect(logs).toHaveLength(2);
+    });
+
+    it("fails safe: throwing forceKeep at rate 0 is dropped", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 0,
+        forceKeep: () => {
+          throw new Error("boom");
+        },
+      });
+
+      ctx.run({}, () => {
+        log.child().emitWideEvent({ message: "dropped", level: "info" });
+      });
+
+      expect(logs).toHaveLength(0);
+    });
+
+    it("fails safe: throwing forceKeep with passing rate is kept", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "default",
+        rate: 1,
+        forceKeep: () => {
+          throw new Error("boom");
+        },
+      });
+
+      ctx.run({}, () => {
+        log.child().emitWideEvent({ message: "kept", level: "info" });
+      });
+
+      expect(logs).toHaveLength(1);
+    });
+
+    it("receives wideData and the resolved level", () => {
+      const seen: Array<{ wideData: Record<string, any>; level: string }> = [];
+      const { log, ctx } = createLogWithCapture({
+        strategy: "default",
+        rate: 1,
+        emitLevel: "warn",
+        forceKeep: (params) => {
+          seen.push({ wideData: params.wideData, level: params.level });
+          return false;
+        },
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ userId: "u1" });
+        logger.emitWideEvent({ message: "no explicit level" }); // uses emitLevel "warn"
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0].level).toBe("warn");
+      expect(seen[0].wideData).toMatchObject({ userId: "u1" });
+    });
+
+    it("works with per_level (issue scenario)", () => {
+      const { log, ctx, logs } = createLogWithCapture({
+        strategy: "per_level",
+        perLevel: { info: 0 }, // drop all info
+        forceKeep: ({ wideData }) => wideData.debug === true,
+      });
+
+      ctx.run({}, () => {
+        const logger = log.child();
+        logger.withWideEvents({ debug: true });
+        logger.emitWideEvent({ message: "kept-debug", level: "info" });
+
+        logger.clearWideEvents();
+        logger.withWideEvents({ debug: false });
+        logger.emitWideEvent({ message: "dropped", level: "info" });
+      });
+
+      const kept = logs.map((l) => l.messages[0]);
+      expect(kept).toContain("kept-debug");
+      expect(kept).not.toContain("dropped");
+    });
+  });
+
+  describe("thrown callback observability", () => {
+    it("logs forceKeep throw only when consoleDebug is enabled", () => {
+      const errors: any[][] = [];
+      const spy = console.error;
+      console.error = (...args: any[]) => {
+        errors.push(args);
+      };
+      try {
+        const ctx = new AsyncLocalStorage<Record<string, any>>();
+        const transport = new BlankTransport({ shipToLogger: (p) => p.messages });
+        const mixin = createWideEventMixin({
+          asyncContext: ctx,
+          sampling: {
+            rate: 1,
+            forceKeep: () => {
+              throw new Error("boom");
+            },
+          },
+        });
+        useLogLayerMixin(mixin);
+
+        // consoleDebug off (default) — no log
+        const logOff = new LogLayer({ transport });
+        ctx.run({}, () => logOff.child().emitWideEvent({ message: "x", level: "info" }));
+        expect(errors).toHaveLength(0);
+
+        // consoleDebug on — one [LogLayer] error
+        const logOn = new LogLayer({ transport, consoleDebug: true });
+        ctx.run({}, () => logOn.child().emitWideEvent({ message: "y", level: "info" }));
+        expect(errors).toHaveLength(1);
+        expect(String(errors[0][0])).toContain("[LogLayer]");
+        expect(String(errors[0][0])).toContain("forceKeep");
+      } finally {
+        console.error = spy;
+      }
+    });
+
+    it("logs shouldEmit throw only when consoleDebug is enabled and still keeps (fail-open)", () => {
+      const errors: any[][] = [];
+      const spy = console.error;
+      console.error = (...args: any[]) => {
+        errors.push(args);
+      };
+      try {
+        const ctx = new AsyncLocalStorage<Record<string, any>>();
+        const captured: any[] = [];
+        const transport = new BlankTransport({
+          shipToLogger: (p) => {
+            captured.push(p.messages);
+            return p.messages;
+          },
+        });
+        const mixin = createWideEventMixin({
+          asyncContext: ctx,
+          sampling: {
+            rate: 1,
+            shouldEmit: () => {
+              throw new Error("boom");
+            },
+          },
+        });
+        useLogLayerMixin(mixin);
+
+        const logOn = new LogLayer({ transport, consoleDebug: true });
+        ctx.run({}, () => logOn.child().emitWideEvent({ message: "z", level: "info" }));
+
+        expect(captured).toHaveLength(1); // fail-open: kept
+        expect(errors).toHaveLength(1);
+        expect(String(errors[0][0])).toContain("shouldEmit");
+      } finally {
+        console.error = spy;
+      }
     });
   });
 });

--- a/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
+++ b/packages/mixins/wide-events/src/__tests__/type-tests.test.ts
@@ -124,6 +124,14 @@ describe("Type Tests", () => {
     };
     createWideEventMixin({ asyncContext: new AsyncLocalStorage(), sampling: config4 });
 
+    // forceKeep callback
+    const config5: WideEventSamplingConfig = {
+      strategy: "per_level",
+      perLevel: { info: 0.01 },
+      forceKeep: ({ wideData, level }) => wideData.debug === true && level === "info",
+    };
+    createWideEventMixin({ asyncContext: new AsyncLocalStorage(), sampling: config5 });
+
     // Type check: strategy is literal
     expectTypeOf<WideEventSamplingStrategy>().toEqualTypeOf<"default" | "per_level">();
   });

--- a/packages/mixins/wide-events/src/mixin.ts
+++ b/packages/mixins/wide-events/src/mixin.ts
@@ -4,6 +4,7 @@ import {
   LogLayerMixinAugmentType,
   type LogLayerMixinRegistration,
   type LogLayerPlugin,
+  type LogLevelType,
 } from "loglayer";
 import type { EmitWideEventConfig, WideEventMixinOptions, WideEventSamplingConfig } from "./types.js";
 
@@ -120,6 +121,7 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
         perLevel: snapshotPerLevel,
         emitLevel: options.sampling.emitLevel,
         shouldEmit: options.sampling.shouldEmit,
+        forceKeep: options.sampling.forceKeep,
       }
     : undefined;
 
@@ -288,6 +290,63 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
   }
 
   /**
+   * Logs a thrown sampling callback via console.error, gated on `consoleDebug`.
+   * Matches loglayer's emit-path error convention (see LogLayer.ts:1457).
+   */
+  function logCallbackError(callbackName: string, err: unknown, self: any): void {
+    if (self.getConfig?.()?.consoleDebug) {
+      console.error(`[LogLayer] wide-events ${callbackName} callback threw; falling back:`, err);
+    }
+  }
+
+  /**
+   * Single sampling decision for an emit. Only called when a `forceKeep` or
+   * `shouldEmit` callback is configured (the no-callback case is handled by the
+   * pre-build fast-path in emitWideEventImpl).
+   *
+   * - `forceKeep` runs first (OR logic): true → keep; throws → fail-safe (log +
+   *   fall through); false → fall through.
+   * - Standard logic: rate AND `shouldEmit` (shouldEmit throws → fail-open, log
+   *   + keep). Without `shouldEmit`, rate alone decides.
+   *
+   * Invokes `runRateSampling` at most once.
+   */
+  function evaluateSampling(wideData: Record<string, any>, level: LogLevelType, self: any): boolean {
+    // forceKeep: keep-only override, evaluated before rate/shouldEmit
+    if (samplingConfig?.forceKeep) {
+      try {
+        if (samplingConfig.forceKeep({ wideData, level })) {
+          return true;
+        }
+        // returned false → fall through to standard logic
+      } catch (err) {
+        // fail-safe: log and fall through to standard logic
+        logCallbackError("forceKeep", err, self);
+      }
+    }
+
+    // Standard logic: rate AND shouldEmit (unchanged semantics)
+    if (samplingConfig?.shouldEmit) {
+      try {
+        const callbackOk = samplingConfig.shouldEmit({ wideData, level });
+        const ratePassed = runRateSampling(
+          level,
+          samplingConfig.strategy,
+          samplingConfig.rate,
+          samplingConfig.perLevel,
+        );
+        return ratePassed && callbackOk;
+      } catch (err) {
+        // fail-open: log and keep
+        logCallbackError("shouldEmit", err, self);
+        return true;
+      }
+    }
+
+    return runRateSampling(level, samplingConfig?.strategy, samplingConfig?.rate, samplingConfig?.perLevel);
+  }
+
+  /**
    * Implementation for emitWideEvent
    */
   function emitWideEventImpl(config: EmitWideEventConfig, self: any): void {
@@ -295,10 +354,12 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
     const defaultLevel = samplingConfig?.emitLevel ?? "info";
     const level = config.level ?? defaultLevel;
 
-    // Check non-callback rate sampling early (skip data building when possible)
+    // Pre-build fast-path: drop before building data when no callback needs wideData.
+    // Skipped when forceKeep OR shouldEmit is set (both need wideData).
     if (
       samplingConfig &&
       !samplingConfig.shouldEmit &&
+      !samplingConfig.forceKeep &&
       !runRateSampling(level, samplingConfig.strategy, samplingConfig.rate, samplingConfig.perLevel)
     ) {
       return;
@@ -320,24 +381,11 @@ export function createWideEventMixin(options: WideEventMixinOptions): LogLayerMi
       Object.assign(wideEventData, store._llWideEvents);
     }
 
-    // Run custom callback sampling (now that data is available)
-    if (samplingConfig?.shouldEmit) {
-      // Custom callback can override error/fatal exemption — run it for all levels
-      // Fail-open: if callback throws, keep everything (override rate check too)
-      try {
-        const callbackOk = samplingConfig.shouldEmit({ wideData: wideEventData, level });
-        // Run rate sampling if callback passed
-        const ratePassed = runRateSampling(
-          level,
-          samplingConfig.strategy,
-          samplingConfig.rate,
-          samplingConfig.perLevel,
-        );
-        if (!ratePassed || !callbackOk) {
-          return;
-        }
-      } catch {
-        // Callback threw — fail-open: keep the event (fall through to emit)
+    // Callback-aware sampling decision (only when a callback is configured;
+    // the no-callback case was already handled by the fast-path above).
+    if (samplingConfig && (samplingConfig.forceKeep || samplingConfig.shouldEmit)) {
+      if (!evaluateSampling(wideEventData, level, self)) {
+        return;
       }
     }
 

--- a/packages/mixins/wide-events/src/types.ts
+++ b/packages/mixins/wide-events/src/types.ts
@@ -124,6 +124,9 @@ export interface WideEventSamplingConfig {
    * `forceKeep` can only rescue events — it never drops an event that standard
    * logic would keep (`error`/`fatal` stay exempt).
    *
+   * Treat `wideData` as read-only: it is passed by reference and mutating it
+   * changes what gets emitted.
+   *
    * If it throws, it fails **safe**: the throw is swallowed and evaluation
    * falls through to the standard rate/`shouldEmit` logic (unlike `shouldEmit`,
    * which fails open). A swallowed throw is logged via `console.error` when

--- a/packages/mixins/wide-events/src/types.ts
+++ b/packages/mixins/wide-events/src/types.ts
@@ -114,6 +114,35 @@ export interface WideEventSamplingConfig {
   shouldEmit?: (params: WideEventSamplingParams) => boolean;
 
   /**
+   * A keep-only override evaluated **before** the rate/`shouldEmit` checks.
+   * When it returns `true`, the event is emitted immediately, bypassing the
+   * rate check and `shouldEmit`. When it returns `false`, standard
+   * rate/`shouldEmit` logic applies. Receives the same params as `shouldEmit`,
+   * so any external signal (e.g. an HTTP header) must first be written into the
+   * wide event via `withWideEvents()`.
+   *
+   * `forceKeep` can only rescue events — it never drops an event that standard
+   * logic would keep (`error`/`fatal` stay exempt).
+   *
+   * If it throws, it fails **safe**: the throw is swallowed and evaluation
+   * falls through to the standard rate/`shouldEmit` logic (unlike `shouldEmit`,
+   * which fails open). A swallowed throw is logged via `console.error` when
+   * `consoleDebug` is enabled.
+   *
+   * @example
+   * ```ts
+   * {
+   *   strategy: "per_level",
+   *   perLevel: { info: 0.01 },
+   *   forceKeep: ({ wideData }) =>
+   *     wideData?.debug === true ||
+   *     (wideData?.deps?.someService?.failures ?? 0) > 0,
+   * }
+   * ```
+   */
+  forceKeep?: (params: WideEventSamplingParams) => boolean;
+
+  /**
    * Override the default log level when no explicit `level` is passed to
    * `emitWideEvent()`. When set, the resolved level uses this value instead
    * of `"info"`. This **does** affect sampling decisions — with `per_level`


### PR DESCRIPTION
Closes #412

## Summary

Adds an optional keep-only `forceKeep` callback to `@loglayer/mixin-wide-events` sampling. It's evaluated **before** the rate/`shouldEmit` checks with OR logic, so it can **rescue** events the configured rate would otherwise drop — e.g. sample 2xx responses at 1% but always keep requests flagged for debugging or showing a downstream failure. Previously the only sampling controls (`rate`, `perLevel`, `shouldEmit`) could restrict emission but never force-keep an info-level event.

## Behavior

- `forceKeep` returns `true` → emit immediately, bypassing the rate check and `shouldEmit`.
- Returns `false` → apply standard rate/`shouldEmit` logic (unchanged).
- **Keep-only:** it can rescue but never drop — `error`/`fatal` stay exempt and it never suppresses an event standard logic would keep.
- **Fails safe** on throw: swallows and falls through to the rate check, so a broken override can't blow past the sampling budget (contrast with `shouldEmit`, which fails open).
- Receives the same params as `shouldEmit` (`{ wideData, level }`), so external signals (e.g. an HTTP header) must be written into the wide event via `withWideEvents()` first.

## Observability

Both `forceKeep` and `shouldEmit`, when they throw, now log via `console.error("[LogLayer] ...")` gated on `consoleDebug` (previously `shouldEmit`'s throw was a silent `catch {}`). Keep/drop semantics are unchanged.

## Implementation notes

- The sampling decision is consolidated into a single `evaluateSampling(wideData, level, self)` helper.
- The pre-build fast-path early-return is skipped when `forceKeep` is set (it needs `wideData`).
- `runRateSampling` is invoked at most once per emit (no double `Math.random()` roll).
- Fully backward compatible: with no `forceKeep`, behavior is identical to before.

## Testing

- New `forceKeep` and observability test suites (rescue, bypass-shouldEmit, fall-through, keep-only/error-exemption, both fail-safe throw paths, resolved-level, per_level, consoleDebug gating).
- Type test for the new config field.
- Full monorepo `turbo build && verify-types && test` green (60/60 test tasks).
- Changeset added (`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)