### PR TITLE
feat(mixin-hot-shots): context-derived tags + MemoryStatsClient

### DIFF
--- a/.changeset/hotshots-context-tags-memory-client.md
+++ b/.changeset/hotshots-context-tags-memory-client.md
@@ -1,0 +1,8 @@
+---
+"@loglayer/mixin-hot-shots": minor
+---
+
+Add two opt-in features:
+
+- **Context-derived tags**: pass `contextTagKeys` to `hotshotsMixin()` to automatically promote allowlisted scalar (`string`/`number`/`boolean`) logger-context values to metric tags. The allowlist is mandatory (cardinality guard) and explicit `.withTags()` tags override derived tags on the same key.
+- **`MemoryStatsClient`**: a StatsD-compatible client that records structured `{ type, name, value, tags, sampleRate }` records instead of sending, enabling metric assertions in tests without parsing StatsD wire format.

--- a/docs/src/cheatsheet.md
+++ b/docs/src/cheatsheet.md
@@ -394,3 +394,5 @@ See [Basic Logging](/logging-api/basic-logging#raw-logging) for context behavior
 | Mock for tests | `new MockLogLayer()` | - |
 | Wide events mixin | `@loglayer/mixin-wide-events` | Accumulate data across async boundaries and emit as single log entry (canonical log line). Sampling: `error`/`fatal` default to 100% (overridable via `perLevel`/`shouldEmit`); `forceKeep` can rescue rate-dropped events. |
 | Create wide event mixin | `createWideEventMixin({ asyncContext, sampling: { strategy: 'default', `rate`: 0.1 } })` | - |
+| Hot-shots mixin | `@loglayer/mixin-hot-shots` | StatsD/DogStatsD metrics via `log.stats.*`. `contextTagKeys` auto-promotes allowlisted scalar context values to tags. |
+| Hot-shots metrics testing | `new MemoryStatsClient()` + `hotshotsMixin(client)` | Records structured `{ type, name, value, tags, sampleRate }` in `client.records`; `client.clear()` to reset. |

--- a/docs/src/mixins/hot-shots.md
+++ b/docs/src/mixins/hot-shots.md
@@ -136,6 +136,37 @@ mockLogger.stats.timing('timer', 500).send();
 
 For more information on testing with MockLogLayer, see the [Unit Testing documentation](/logging-api/unit-testing).
 
+### Testing with MemoryStatsClient
+
+`MemoryStatsClient` records structured metric records instead of sending them,
+so tests can assert on metrics without parsing StatsD wire format:
+
+```typescript
+import { hotshotsMixin, MemoryStatsClient } from '@loglayer/mixin-hot-shots';
+import { LogLayer, useLogLayerMixin } from 'loglayer';
+
+const stats = new MemoryStatsClient();
+useLogLayerMixin(hotshotsMixin(stats));
+
+const log = new LogLayer({ transport: /* ... */ });
+log.stats.increment('dependency.count').withTags(['dependency:coreApi']).send();
+
+expect(stats.records).toContainEqual({
+  type: 'increment',
+  name: 'dependency.count',
+  value: 1,
+  tags: ['dependency:coreApi'],
+  sampleRate: undefined,
+});
+
+stats.clear(); // reset between tests
+```
+
+Each `.send()` appends exactly one record `{ type, name, value, tags, sampleRate }`
+(a builder never `.send()`-ed records nothing). `increment`/`decrement` default
+`value` to `1`/`-1`. Note the hot-shots positional caveat: on `increment`/`decrement`,
+a lone `.withSampleRate(r)` (no `.withValue()`) is recorded as the `value`.
+
 ## Configuration Options
 
 The `hotshotsMixin` function requires a configured `StatsD` client instance from the `hot-shots` library.
@@ -147,6 +178,37 @@ The `hotshotsMixin` function requires a configured `StatsD` client instance from
 | `client` | `StatsD` | A configured `StatsD` client instance from the `hot-shots` library |
 
 For detailed information about configuring the `StatsD` client, see the [hot-shots documentation](https://github.com/bdeitte/hot-shots).
+
+### Optional Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `options.contextTagKeys` | `string[]` | `[]` | Allowlist of logger-context keys to automatically promote to metric tags. |
+
+#### Context-Derived Tags
+
+Pass `contextTagKeys` to promote scalar values from the logger's context into
+tags on every metric, without repeating `.withTags()`:
+
+```typescript
+useLogLayerMixin(hotshotsMixin(statsClient, {
+  contextTagKeys: ["endpoint", "method", "status_code"],
+}));
+
+// Tagged with endpoint:/v1/x automatically:
+log.withContext({ endpoint: "/v1/x" }).stats.increment("request.count").send();
+```
+
+Rules:
+
+- **Allowlist is mandatory** — only listed keys are promoted. This prevents
+  high-cardinality values (e.g. `userId`, `reqId`) from inflating metric costs.
+- **Scalars only** — only `string`/`number`/`boolean` context values are
+  promoted; missing keys, `null`/`undefined`, objects, and arrays are skipped.
+- **Explicit tags win** — a `.withTags()` tag overrides a derived tag on the same
+  key; no duplicate keys are emitted.
+- Context is read from the logger the `.stats` call is made on
+  (`log.withContext({...}).stats...`), resolved at `send()` time.
 
 ## Available Methods
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -1391,7 +1391,7 @@ useLogLayerMixin({ mixinsToAdd: [metricsMixin] })
 ## Available Mixins
 
 - `@loglayer/mixin-wide-events` - Accumulate telemetry across async boundaries and emit as a single log entry (canonical log line). Wide event data is always emitted flat at the root level, regardless of `metadataFieldName` configuration. Supports configurable sampling (`rate` or `perLevel`) with `error`/`fatal` defaulting to 100% (can be overridden), a `shouldEmit` restrictor callback, and a keep-only `forceKeep` override that rescues events the rate would drop (fails safe on throw).
-- `@loglayer/mixin-hot-shots` - Hot-Shots (StatsD) metrics
+- `@loglayer/mixin-hot-shots` - Hot-Shots (StatsD) metrics. Optional `contextTagKeys` promotes allowlisted scalar logger-context values to metric tags (scalars only, explicit tags win). `MemoryStatsClient` records structured `{ type, name, value, tags, sampleRate }` records for test assertions instead of StatsD wire format.
 
 ## Available Context Managers
 

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -367,7 +367,7 @@ Other: HTTP, Log File Rotation, OpenTelemetry
 - [Log Level Managers](https://loglayer.dev/log-level-managers/): Customize log level behavior
 - [Mixins](https://loglayer.dev/mixins/): Extend LogLayer with custom methods
   - [Wide Events](https://loglayer.dev/mixins/wide-events): Accumulate data across async boundaries and emit as single log entry; wide event data is always flat at root level (ignores metadataFieldName); supports configurable sampling (default/per-level) with error/fatal defaulting to 100% (can be overridden), plus a keep-only `forceKeep` override to rescue rate-dropped events
-  - [Hot-Shots](https://loglayer.dev/mixins/hot-shots): Emit StatsD/dogstatsd metrics from log entries
+  - [Hot-Shots](https://loglayer.dev/mixins/hot-shots): Emit StatsD/dogstatsd metrics from log entries; optional `contextTagKeys` promotes allowlisted scalar context values to tags; `MemoryStatsClient` records structured metrics for testing
   - [Datadog HTTP Metrics](https://loglayer.dev/mixins/datadog-http-metrics): Send metrics to Datadog HTTP endpoint
 - [ElysiaJS Integration](https://loglayer.dev/integrations/elysia): ElysiaJS plugin with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering
 - [Express Integration](https://loglayer.dev/integrations/express): Express middleware with request-scoped logging, optional `group` config to tag auto-logged messages with groups for routing/filtering

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -7,6 +7,13 @@ description: Learn about the latest features and improvements in LogLayer
 
 - [`loglayer` Changelog](/core-changelogs/loglayer-changelog)
 
+## Jul 3, 2026
+
+`@loglayer/mixin-hot-shots`:
+
+- **Context-derived tags**: pass `contextTagKeys` to `hotshotsMixin()` to automatically promote allowlisted scalar context values to metric tags.
+- **`MemoryStatsClient`**: a StatsD-compatible client that records structured metric records for assertions in tests, replacing StatsD wire-format string parsing.
+
 ## Jul 2, 2026
 
 `@loglayer/mixin-wide-events`:

--- a/packages/mixins/hot-shots/src/CommonStatsBuilder.ts
+++ b/packages/mixins/hot-shots/src/CommonStatsBuilder.ts
@@ -14,6 +14,8 @@ export abstract class CommonStatsBuilder implements IStatsBuilder {
   protected callback?: StatsCallback;
   /** The hot-shots client instance */
   protected readonly client: StatsD;
+  /** Resolver for context-derived tags; injected by StatsAPI. Undefined when no allowlist is configured. */
+  public deriveContextTags?: () => string[];
 
   /**
    * Creates a new CommonStatsBuilder instance.
@@ -59,19 +61,35 @@ export abstract class CommonStatsBuilder implements IStatsBuilder {
   }
 
   /**
-   * Convert tags to the format hot-shots expects (array of strings)
+   * Normalize explicit tags (array or object) to an array of `key:value` strings.
    */
-  protected convertTags(): string[] | undefined {
+  private normalizeExplicitTags(): string[] {
     if (!this.tags) {
-      return undefined;
+      return [];
     }
-
     if (Array.isArray(this.tags)) {
       return this.tags;
     }
-
     // Convert object to array format: ["key:value", "key2:value2"]
     return Object.entries(this.tags).map(([key, value]) => `${key}:${value}`);
+  }
+
+  /**
+   * Convert tags to the format hot-shots expects (array of strings), merging
+   * context-derived tags. Explicit tags win: a derived tag is included only
+   * when its key is not already present in the explicit tags.
+   */
+  protected convertTags(): string[] | undefined {
+    const explicit = this.normalizeExplicitTags();
+    const derived = this.deriveContextTags?.() ?? [];
+
+    if (derived.length === 0) {
+      return explicit.length ? explicit : undefined;
+    }
+
+    const explicitKeys = new Set(explicit.map((tag) => tagKey(tag)));
+    const merged = [...explicit, ...derived.filter((tag) => !explicitKeys.has(tagKey(tag)))];
+    return merged.length ? merged : undefined;
   }
 
   /**
@@ -107,4 +125,13 @@ export abstract class CommonStatsBuilder implements IStatsBuilder {
    * Abstract method that each builder must implement to send the metric
    */
   abstract send(): void;
+}
+
+/**
+ * Extract the key portion of a `key:value` tag (substring before the first `:`).
+ * A tag with no `:` is its own key.
+ */
+function tagKey(tag: string): string {
+  const idx = tag.indexOf(":");
+  return idx === -1 ? tag : tag.slice(0, idx);
 }

--- a/packages/mixins/hot-shots/src/LogBuilder.augment.ts
+++ b/packages/mixins/hot-shots/src/LogBuilder.augment.ts
@@ -15,6 +15,28 @@ export function setStatsClient(client: StatsD | null): void {
   statsClient = client;
 }
 
+// Store the allowlist of context keys to promote to tags - set during mixin registration
+let contextTagKeys: string[] = [];
+
+/**
+ * Set the allowlist of logger-context keys to promote to metric tags.
+ * Called during mixin registration.
+ *
+ * @param keys - The context keys to promote (undefined clears the allowlist)
+ */
+export function setContextTagKeys(keys: string[] | undefined): void {
+  contextTagKeys = keys ?? [];
+}
+
+/**
+ * Get the allowlist of context keys to promote to metric tags.
+ *
+ * @returns The configured context tag keys (empty array if none)
+ */
+export function getContextTagKeys(): string[] {
+  return contextTagKeys;
+}
+
 /**
  * Check if the client is null (no-op mode)
  *

--- a/packages/mixins/hot-shots/src/LogLayer.augment.ts
+++ b/packages/mixins/hot-shots/src/LogLayer.augment.ts
@@ -1,7 +1,8 @@
 import type { LogLayer, LogLayerMixin } from "loglayer";
 import { LogLayerMixinAugmentType } from "loglayer";
 import "./types.js"; // Import types to ensure declarations are processed
-import { getStatsClient, isNoOpClient } from "./LogBuilder.augment.js";
+import { deriveContextTags } from "./deriveContextTags.js";
+import { getContextTagKeys, getStatsClient, isNoOpClient } from "./LogBuilder.augment.js";
 import { MockStatsAPI } from "./MockStatsAPI.js";
 import { StatsAPI } from "./StatsAPI.js";
 
@@ -16,8 +17,13 @@ export const logLayerHotShotsMixin: LogLayerMixin = {
       get(this: LogLayer) {
         // Create stats API lazily and cache it
         if (!(this as any)._statsAPI) {
-          // Use MockStatsAPI if no client is configured, otherwise use real StatsAPI
-          (this as any)._statsAPI = isNoOpClient() ? new MockStatsAPI() : new StatsAPI(getStatsClient());
+          if (isNoOpClient()) {
+            (this as any)._statsAPI = new MockStatsAPI();
+          } else {
+            const keys = getContextTagKeys();
+            const deriveTags = keys.length ? () => deriveContextTags(this.getContext(), keys) : undefined;
+            (this as any)._statsAPI = new StatsAPI(getStatsClient(), deriveTags);
+          }
         }
         return (this as any)._statsAPI;
       },
@@ -32,10 +38,18 @@ export const logLayerHotShotsMixin: LogLayerMixin = {
   augmentMock: (prototype) => {
     // Mock implementation - return a no-op stats API
     Object.defineProperty(prototype, "stats", {
-      get() {
+      get(this: any) {
         if (!(this as any)._statsAPI) {
-          // Use MockStatsAPI if no client is configured, otherwise use real StatsAPI
-          (this as any)._statsAPI = isNoOpClient() ? new MockStatsAPI() : new StatsAPI(getStatsClient());
+          if (isNoOpClient()) {
+            (this as any)._statsAPI = new MockStatsAPI();
+          } else {
+            const keys = getContextTagKeys();
+            const deriveTags =
+              keys.length && typeof this.getContext === "function"
+                ? () => deriveContextTags(this.getContext(), keys)
+                : undefined;
+            (this as any)._statsAPI = new StatsAPI(getStatsClient(), deriveTags);
+          }
         }
         return (this as any)._statsAPI;
       },

--- a/packages/mixins/hot-shots/src/MemoryStatsClient.ts
+++ b/packages/mixins/hot-shots/src/MemoryStatsClient.ts
@@ -1,0 +1,162 @@
+import type { StatsRecord } from "./types.js";
+
+type AnyFn = (...args: any[]) => any;
+
+/** Normalize a stat name (array stats are joined with a comma). */
+function statName(stat: string | string[]): string {
+  return Array.isArray(stat) ? stat.join(",") : stat;
+}
+
+/**
+ * Parse the trailing builder args (sampleRate?, tags?, callback?) in the fixed
+ * order the hot-shots builders emit them.
+ */
+function parseOpts(args: unknown[]): {
+  sampleRate?: number;
+  tags?: string[];
+  callback?: AnyFn;
+} {
+  let i = 0;
+  const sampleRate = typeof args[i] === "number" ? (args[i++] as number) : undefined;
+  const tags = Array.isArray(args[i]) ? (args[i++] as string[]) : undefined;
+  const callback = typeof args[i] === "function" ? (args[i++] as AnyFn) : undefined;
+  return { sampleRate, tags, callback };
+}
+
+/**
+ * An in-memory StatsD-compatible client that records structured metric records
+ * instead of sending them over the network. Pass it to `hotshotsMixin()` in
+ * tests and assert against `records`.
+ *
+ * @example
+ * ```ts
+ * const stats = new MemoryStatsClient();
+ * useLogLayerMixin(hotshotsMixin(stats));
+ * // ...exercise code...
+ * expect(stats.records).toContainEqual({ type: "increment", name: "x", value: 1, tags: undefined, sampleRate: undefined });
+ * ```
+ */
+export class MemoryStatsClient {
+  /** Structured records of every metric sent through this client. */
+  readonly records: StatsRecord[] = [];
+
+  /** Clear all recorded metrics. */
+  clear(): void {
+    this.records.length = 0;
+  }
+
+  private record(record: StatsRecord, callback?: AnyFn): void {
+    this.records.push(record);
+    callback?.(undefined);
+  }
+
+  increment(stat: string | string[], ...args: unknown[]): void {
+    const value = typeof args[0] === "number" ? (args.shift() as number) : 1;
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "increment", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  decrement(stat: string | string[], ...args: unknown[]): void {
+    const value = typeof args[0] === "number" ? (args.shift() as number) : -1;
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "decrement", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  gauge(stat: string | string[], value: number, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "gauge", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  gaugeDelta(stat: string | string[], value: number, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "gaugeDelta", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  histogram(stat: string | string[], value: number, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "histogram", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  distribution(stat: string | string[], value: number, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "distribution", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  timing(stat: string | string[], value: number | Date, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "timing", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  set(stat: string | string[], value: string | number, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "set", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  unique(stat: string | string[], value: string | number, ...args: unknown[]): void {
+    const { sampleRate, tags, callback } = parseOpts(args);
+    this.record({ type: "unique", name: statName(stat), value, tags, sampleRate }, callback);
+  }
+
+  event(title: string, text?: string, ...args: unknown[]): void {
+    // Builder passes an explicit `undefined` options slot before tags/callback.
+    if (args.length && args[0] === undefined) {
+      args.shift();
+    }
+    const tags = Array.isArray(args[0]) ? (args.shift() as string[]) : undefined;
+    const callback = typeof args[0] === "function" ? (args.shift() as AnyFn) : undefined;
+    this.record({ type: "event", name: title, text, tags }, callback);
+  }
+
+  check(name: string, status: number, ...args: unknown[]): void {
+    // Builder emits: check(name, status, options?, tags?, callback?) — options is a
+    // non-array object and only present when withOptions() was used.
+    if (args[0] !== null && typeof args[0] === "object" && !Array.isArray(args[0])) {
+      args.shift();
+    }
+    const tags = Array.isArray(args[0]) ? (args.shift() as string[]) : undefined;
+    const callback = typeof args[0] === "function" ? (args.shift() as AnyFn) : undefined;
+    this.record({ type: "check", name, status, tags }, callback);
+  }
+
+  // Timer builders use a positional convention (func, stat, sampleRate?, tags?,
+  // callback?) — sampleRate is always at position 0 of the rest args (even when
+  // undefined), unlike the compact direct-metric args — so parse positionally.
+  timer(func: AnyFn, stat: string | string[], sampleRate?: number, tags?: string[]): AnyFn {
+    return (...callArgs: unknown[]) => {
+      const start = Date.now();
+      try {
+        return func(...callArgs);
+      } finally {
+        this.records.push({ type: "timer", name: statName(stat), value: Date.now() - start, tags, sampleRate });
+      }
+    };
+  }
+
+  asyncTimer(func: AnyFn, stat: string | string[], sampleRate?: number, tags?: string[]): AnyFn {
+    return async (...callArgs: unknown[]) => {
+      const start = Date.now();
+      try {
+        return await func(...callArgs);
+      } finally {
+        this.records.push({ type: "asyncTimer", name: statName(stat), value: Date.now() - start, tags, sampleRate });
+      }
+    };
+  }
+
+  asyncDistTimer(func: AnyFn, stat: string | string[], sampleRate?: number, tags?: string[]): AnyFn {
+    return async (...callArgs: unknown[]) => {
+      const start = Date.now();
+      try {
+        return await func(...callArgs);
+      } finally {
+        this.records.push({
+          type: "asyncDistTimer",
+          name: statName(stat),
+          value: Date.now() - start,
+          tags,
+          sampleRate,
+        });
+      }
+    };
+  }
+}

--- a/packages/mixins/hot-shots/src/StatsAPI.ts
+++ b/packages/mixins/hot-shots/src/StatsAPI.ts
@@ -13,6 +13,7 @@ import { TimerBuilder } from "./builders/TimerBuilder.js";
 import { TimingBuilder } from "./builders/TimingBuilder.js";
 import { UniqueBuilder } from "./builders/UniqueBuilder.js";
 import { CheckBuilder } from "./CheckBuilder.js";
+import type { CommonStatsBuilder } from "./CommonStatsBuilder.js";
 import type {
   IAsyncDistTimerBuilder,
   IAsyncTimerBuilder,
@@ -33,8 +34,20 @@ export class StatsAPI implements IStatsAPI {
    * Creates a new StatsAPI instance.
    *
    * @param client - The hot-shots StatsD client instance to use for sending metrics
+   * @param deriveTags - Optional resolver returning context-derived tag strings
    */
-  constructor(private readonly client: StatsD) {}
+  constructor(
+    private readonly client: StatsD,
+    private readonly deriveTags?: () => string[],
+  ) {}
+
+  /**
+   * Attach the context-tag resolver to a builder before returning it.
+   */
+  private withContext<B extends CommonStatsBuilder>(builder: B): B {
+    builder.deriveContextTags = this.deriveTags;
+    return builder;
+  }
 
   /**
    * Increment a counter metric.
@@ -44,7 +57,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   increment(stat: string | string[]): IIncrementDecrementBuilder {
-    return new IncrementBuilder(this.client, stat);
+    return this.withContext(new IncrementBuilder(this.client, stat));
   }
 
   /**
@@ -55,7 +68,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   decrement(stat: string | string[]): IIncrementDecrementBuilder {
-    return new DecrementBuilder(this.client, stat);
+    return this.withContext(new DecrementBuilder(this.client, stat));
   }
 
   /**
@@ -67,7 +80,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   gauge(stat: string | string[], value: number): IStatsBuilder {
-    return new GaugeBuilder(this.client, stat, value);
+    return this.withContext(new GaugeBuilder(this.client, stat, value));
   }
 
   /**
@@ -79,7 +92,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   gaugeDelta(stat: string | string[], delta: number): IStatsBuilder {
-    return new GaugeDeltaBuilder(this.client, stat, delta);
+    return this.withContext(new GaugeDeltaBuilder(this.client, stat, delta));
   }
 
   /**
@@ -91,7 +104,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   histogram(stat: string | string[], value: number): IStatsBuilder {
-    return new HistogramBuilder(this.client, stat, value);
+    return this.withContext(new HistogramBuilder(this.client, stat, value));
   }
 
   /**
@@ -103,7 +116,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   distribution(stat: string | string[], value: number): IStatsBuilder {
-    return new DistributionBuilder(this.client, stat, value);
+    return this.withContext(new DistributionBuilder(this.client, stat, value));
   }
 
   /**
@@ -115,7 +128,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   timing(stat: string | string[], value: number | Date): IStatsBuilder {
-    return new TimingBuilder(this.client, stat, value);
+    return this.withContext(new TimingBuilder(this.client, stat, value));
   }
 
   /**
@@ -127,7 +140,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   set(stat: string | string[], value: string | number): IStatsBuilder {
-    return new SetBuilder(this.client, stat, value);
+    return this.withContext(new SetBuilder(this.client, stat, value));
   }
 
   /**
@@ -139,7 +152,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   unique(stat: string | string[], value: string | number): IStatsBuilder {
-    return new UniqueBuilder(this.client, stat, value);
+    return this.withContext(new UniqueBuilder(this.client, stat, value));
   }
 
   /**
@@ -150,7 +163,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   event(title: string): IEventBuilder {
-    return new EventBuilder(this.client, title);
+    return this.withContext(new EventBuilder(this.client, title));
   }
 
   /**
@@ -162,7 +175,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   check(name: string, status: DatadogChecksValues): ICheckBuilder {
-    return new CheckBuilder(this.client, name, status);
+    return this.withContext(new CheckBuilder(this.client, name, status));
   }
 
   /**
@@ -175,7 +188,7 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   asyncTimer<P extends unknown[], R>(func: (...args: P) => Promise<R>, stat: string | string[]): IAsyncTimerBuilder {
-    return new AsyncTimerBuilder(this.client, func as (...args: unknown[]) => Promise<unknown>, stat);
+    return this.withContext(new AsyncTimerBuilder(this.client, func as (...args: unknown[]) => Promise<unknown>, stat));
   }
 
   /**
@@ -191,7 +204,9 @@ export class StatsAPI implements IStatsAPI {
     func: (...args: P) => Promise<R>,
     stat: string | string[],
   ): IAsyncDistTimerBuilder {
-    return new AsyncDistTimerBuilder(this.client, func as (...args: unknown[]) => Promise<unknown>, stat);
+    return this.withContext(
+      new AsyncDistTimerBuilder(this.client, func as (...args: unknown[]) => Promise<unknown>, stat),
+    );
   }
 
   /**
@@ -204,6 +219,6 @@ export class StatsAPI implements IStatsAPI {
    * @returns A builder instance for chaining additional options
    */
   timer<P extends unknown[], R>(func: (...args: P) => R, stat: string | string[]): ITimerBuilder {
-    return new TimerBuilder(this.client, func as (...args: unknown[]) => unknown, stat);
+    return this.withContext(new TimerBuilder(this.client, func as (...args: unknown[]) => unknown, stat));
   }
 }

--- a/packages/mixins/hot-shots/src/__tests__/contextTags.test.ts
+++ b/packages/mixins/hot-shots/src/__tests__/contextTags.test.ts
@@ -1,0 +1,90 @@
+import type { StatsD } from "hot-shots";
+import { LogLayer, lazy, TestLoggingLibrary, TestTransport, useLogLayerMixin } from "loglayer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hotshotsMixin } from "../index.js";
+
+function makeMockClient() {
+  return {
+    increment: vi.fn(),
+    decrement: vi.fn(),
+    gauge: vi.fn(),
+    gaugeDelta: vi.fn(),
+    histogram: vi.fn(),
+    distribution: vi.fn(),
+    timing: vi.fn(),
+    set: vi.fn(),
+    unique: vi.fn(),
+    event: vi.fn(),
+    check: vi.fn(),
+  } as unknown as StatsD;
+}
+
+function makeLogger() {
+  return new LogLayer({ transport: new TestTransport({ logger: new TestLoggingLibrary() }) });
+}
+
+describe("context-derived tags", () => {
+  let client: StatsD;
+
+  beforeEach(() => {
+    client = makeMockClient();
+  });
+
+  it("promotes an allowlisted scalar context key to a tag", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["endpoint"] }));
+    makeLogger().withContext({ endpoint: "/v1/x" }).stats.increment("request.count").send();
+    expect(client.increment).toHaveBeenCalledWith("request.count", ["endpoint:/v1/x"]);
+  });
+
+  it("does not promote non-allowlisted keys", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["endpoint"] }));
+    makeLogger().withContext({ endpoint: "/v1/x", userId: "u1" }).stats.increment("c").send();
+    expect(client.increment).toHaveBeenCalledWith("c", ["endpoint:/v1/x"]);
+  });
+
+  it("skips non-scalar context values, promotes number and boolean", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["obj", "arr", "nil", "num", "flag"] }));
+    makeLogger()
+      .withContext({ obj: { a: 1 }, arr: [1, 2], nil: null, num: 42, flag: true })
+      .stats.increment("c")
+      .send();
+    expect(client.increment).toHaveBeenCalledWith("c", ["num:42", "flag:true"]);
+  });
+
+  it("promotes a lazy context value that resolves to a scalar", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["endpoint"] }));
+    makeLogger()
+      .withContext({ endpoint: lazy(() => "/lazy") })
+      .stats.increment("c")
+      .send();
+    expect(client.increment).toHaveBeenCalledWith("c", ["endpoint:/lazy"]);
+  });
+
+  it("emits derived-only tags when no explicit tags are set", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["endpoint"] }));
+    makeLogger().withContext({ endpoint: "/v1/x" }).stats.gauge("g", 5).send();
+    expect(client.gauge).toHaveBeenCalledWith("g", 5, ["endpoint:/v1/x"]);
+  });
+
+  it("explicit tags override a derived key (no duplicate) and keep non-conflicting", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["endpoint", "method"] }));
+    makeLogger()
+      .withContext({ endpoint: "/ctx", method: "GET" })
+      .stats.increment("c")
+      .withTags(["endpoint:/explicit", "extra:1"])
+      .send();
+    expect(client.increment).toHaveBeenCalledWith("c", ["endpoint:/explicit", "extra:1", "method:GET"]);
+  });
+
+  it("supports object explicit tags overriding a derived key", () => {
+    useLogLayerMixin(hotshotsMixin(client, { contextTagKeys: ["endpoint"] }));
+    makeLogger().withContext({ endpoint: "/ctx" }).stats.increment("c").withTags({ endpoint: "/explicit" }).send();
+    expect(client.increment).toHaveBeenCalledWith("c", ["endpoint:/explicit"]);
+  });
+
+  it("no contextTagKeys → no derived tags (regression guard)", () => {
+    useLogLayerMixin(hotshotsMixin(client));
+    makeLogger().withContext({ endpoint: "/v1/x" }).stats.increment("c").send();
+    expect(client.increment).toHaveBeenCalledWith("c");
+  });
+});

--- a/packages/mixins/hot-shots/src/__tests__/memoryStatsClient.test.ts
+++ b/packages/mixins/hot-shots/src/__tests__/memoryStatsClient.test.ts
@@ -1,0 +1,125 @@
+import { LogLayer, TestLoggingLibrary, TestTransport, useLogLayerMixin } from "loglayer";
+import { beforeEach, describe, expect, it } from "vitest";
+import { hotshotsMixin, MemoryStatsClient } from "../index.js";
+
+describe("MemoryStatsClient", () => {
+  let stats: MemoryStatsClient;
+
+  function makeLogger() {
+    return new LogLayer({ transport: new TestTransport({ logger: new TestLoggingLibrary() }) });
+  }
+
+  beforeEach(() => {
+    stats = new MemoryStatsClient();
+    useLogLayerMixin(hotshotsMixin(stats));
+  });
+
+  it("records the issue example shape", () => {
+    makeLogger().stats.increment("dependency.count").withTags(["dependency:coreApi", "outcome:success"]).send();
+
+    expect(stats.records).toContainEqual({
+      type: "increment",
+      name: "dependency.count",
+      value: 1,
+      tags: ["dependency:coreApi", "outcome:success"],
+      sampleRate: undefined,
+    });
+  });
+
+  it("increment defaults value to 1, decrement to -1, and honors withValue", () => {
+    const log = makeLogger();
+    log.stats.increment("a").send();
+    log.stats.increment("b").withValue(5).send();
+    log.stats.decrement("c").send();
+
+    expect(stats.records[0]).toMatchObject({ type: "increment", name: "a", value: 1 });
+    expect(stats.records[1]).toMatchObject({ type: "increment", name: "b", value: 5 });
+    expect(stats.records[2]).toMatchObject({ type: "decrement", name: "c", value: -1 });
+  });
+
+  it("records gauge/histogram/distribution/timing/set/unique with value", () => {
+    const log = makeLogger();
+    log.stats.gauge("g", 3).send();
+    log.stats.histogram("h", 4).send();
+    log.stats.distribution("d", 5).send();
+    log.stats.timing("t", 6).send();
+    log.stats.set("s", "id1").send();
+    log.stats.unique("u", "id2").send();
+
+    expect(stats.records).toEqual([
+      { type: "gauge", name: "g", value: 3, tags: undefined, sampleRate: undefined },
+      { type: "histogram", name: "h", value: 4, tags: undefined, sampleRate: undefined },
+      { type: "distribution", name: "d", value: 5, tags: undefined, sampleRate: undefined },
+      { type: "timing", name: "t", value: 6, tags: undefined, sampleRate: undefined },
+      { type: "set", name: "s", value: "id1", tags: undefined, sampleRate: undefined },
+      { type: "unique", name: "u", value: "id2", tags: undefined, sampleRate: undefined },
+    ]);
+  });
+
+  it("captures tags and sampleRate", () => {
+    makeLogger().stats.gauge("g", 1).withTags(["a:b"]).withSampleRate(0.5).send();
+    expect(stats.records[0]).toEqual({
+      type: "gauge",
+      name: "g",
+      value: 1,
+      tags: ["a:b"],
+      sampleRate: 0.5,
+    });
+  });
+
+  it("increment withSampleRate (no value) records the rate as the value (hot-shots positional semantics)", () => {
+    makeLogger().stats.increment("x").withSampleRate(0.5).send();
+    expect(stats.records[0]).toMatchObject({ type: "increment", name: "x", value: 0.5, sampleRate: undefined });
+  });
+
+  it("builder without send() records nothing", () => {
+    makeLogger().stats.increment("x").withValue(9);
+    expect(stats.records).toHaveLength(0);
+  });
+
+  it("clear() empties records", () => {
+    makeLogger().stats.increment("x").send();
+    expect(stats.records).toHaveLength(1);
+    stats.clear();
+    expect(stats.records).toHaveLength(0);
+  });
+
+  it("records event and check shapes", () => {
+    const log = makeLogger();
+    log.stats.event("deploy").withText("v2 shipped").withTags(["env:prod"]).send();
+    // status 0 = OK for DataDog checks
+    log.stats
+      .check("db", 0 as any)
+      .withTags(["svc:db"])
+      .send();
+
+    expect(stats.records[0]).toMatchObject({ type: "event", name: "deploy", text: "v2 shipped", tags: ["env:prod"] });
+    expect(stats.records[1]).toMatchObject({ type: "check", name: "db", status: 0, tags: ["svc:db"] });
+  });
+
+  it("timer wrapper executes the function and records a timer entry (not timing)", () => {
+    const wrapped = makeLogger()
+      .stats.timer(() => 42, "work.time")
+      .withTags(["op:x"])
+      .create();
+    const result = wrapped();
+    expect(result).toBe(42);
+    const rec = stats.records.find((r) => r.name === "work.time");
+    expect(rec?.type).toBe("timer");
+    expect(rec?.tags).toEqual(["op:x"]);
+    expect(typeof rec?.value).toBe("number");
+  });
+
+  it("composes with context-derived tags (Feature 1 + Feature 2)", () => {
+    const composed = new MemoryStatsClient();
+    useLogLayerMixin(hotshotsMixin(composed, { contextTagKeys: ["endpoint"] }));
+    makeLogger().withContext({ endpoint: "/v1/x" }).stats.increment("c").withTags(["a:b"]).send();
+    expect(composed.records[0]).toEqual({
+      type: "increment",
+      name: "c",
+      value: 1,
+      tags: ["a:b", "endpoint:/v1/x"],
+      sampleRate: undefined,
+    });
+  });
+});

--- a/packages/mixins/hot-shots/src/deriveContextTags.ts
+++ b/packages/mixins/hot-shots/src/deriveContextTags.ts
@@ -1,0 +1,24 @@
+/**
+ * Derive metric tags from a logger context object using an allowlist.
+ *
+ * For each allowlisted key whose context value is a scalar (string/number/
+ * boolean), produces a `key:value` tag string. Missing keys, null/undefined,
+ * objects, and arrays are skipped.
+ *
+ * @param context - The resolved logger context
+ * @param keys - The allowlist of context keys to promote
+ * @returns Tag strings in the form `key:value`
+ */
+export function deriveContextTags(context: Record<string, any> | undefined, keys: string[]): string[] {
+  const tags: string[] = [];
+  if (!context) {
+    return tags;
+  }
+  for (const key of keys) {
+    const value = context[key];
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      tags.push(`${key}:${value}`);
+    }
+  }
+  return tags;
+}

--- a/packages/mixins/hot-shots/src/index.ts
+++ b/packages/mixins/hot-shots/src/index.ts
@@ -1,13 +1,15 @@
 import type { StatsD } from "hot-shots";
 import type { LogLayerMixinRegistration } from "loglayer";
-import { setStatsClient } from "./LogBuilder.augment.js";
+import { setContextTagKeys, setStatsClient } from "./LogBuilder.augment.js";
 import { logLayerHotShotsMixin } from "./LogLayer.augment.js";
+import type { HotShotsMixinOptions } from "./types.js";
 import "./types.js"; // Import types to ensure declarations are processed
 
 export type { StatsD } from "hot-shots";
 export { MockStatsAPI } from "./MockStatsAPI.js";
 export { StatsAPI } from "./StatsAPI.js";
 export type {
+  HotShotsMixinOptions,
   IAsyncDistTimerBuilder,
   IAsyncTimerBuilder,
   ICheckBuilder,
@@ -27,6 +29,7 @@ export type {
  * providing a fluent API for sending metrics to StatsD, DogStatsD, and Telegraf.
  *
  * @param client - The hot-shots StatsD client instance to use for sending metrics
+ * @param options - Optional mixin options (e.g. `contextTagKeys`)
  * @returns A LogLayer mixin registration object
  *
  * @example
@@ -39,9 +42,11 @@ export type {
  * useLogLayerMixin(hotshotsMixin(statsClient));
  * ```
  */
-export function hotshotsMixin(client: StatsD | null): LogLayerMixinRegistration {
+export function hotshotsMixin(client: StatsD | null, options?: HotShotsMixinOptions): LogLayerMixinRegistration {
   // Set the client for the mixin
   setStatsClient(client);
+  // Set the context-tag allowlist (empty when not provided)
+  setContextTagKeys(options?.contextTagKeys);
 
   return {
     mixinsToAdd: [logLayerHotShotsMixin],

--- a/packages/mixins/hot-shots/src/index.ts
+++ b/packages/mixins/hot-shots/src/index.ts
@@ -2,10 +2,12 @@ import type { StatsD } from "hot-shots";
 import type { LogLayerMixinRegistration } from "loglayer";
 import { setContextTagKeys, setStatsClient } from "./LogBuilder.augment.js";
 import { logLayerHotShotsMixin } from "./LogLayer.augment.js";
+import type { MemoryStatsClient } from "./MemoryStatsClient.js";
 import type { HotShotsMixinOptions } from "./types.js";
 import "./types.js"; // Import types to ensure declarations are processed
 
 export type { StatsD } from "hot-shots";
+export { MemoryStatsClient } from "./MemoryStatsClient.js";
 export { MockStatsAPI } from "./MockStatsAPI.js";
 export { StatsAPI } from "./StatsAPI.js";
 export type {
@@ -20,6 +22,7 @@ export type {
   IStatsBuilder,
   ITimerBuilder,
   StatsCallback,
+  StatsRecord,
   StatsTags,
 } from "./types.js";
 
@@ -42,9 +45,12 @@ export type {
  * useLogLayerMixin(hotshotsMixin(statsClient));
  * ```
  */
-export function hotshotsMixin(client: StatsD | null, options?: HotShotsMixinOptions): LogLayerMixinRegistration {
-  // Set the client for the mixin
-  setStatsClient(client);
+export function hotshotsMixin(
+  client: StatsD | MemoryStatsClient | null,
+  options?: HotShotsMixinOptions,
+): LogLayerMixinRegistration {
+  // Set the client for the mixin (MemoryStatsClient duck-types the used StatsD surface)
+  setStatsClient(client as StatsD | null);
   // Set the context-tag allowlist (empty when not provided)
   setContextTagKeys(options?.contextTagKeys);
 

--- a/packages/mixins/hot-shots/src/types.ts
+++ b/packages/mixins/hot-shots/src/types.ts
@@ -11,6 +11,20 @@ export type StatsCallback = (error?: Error, bytes?: number) => void;
 export type StatsTags = string[] | Record<string, string>;
 
 /**
+ * Options for configuring the hot-shots mixin.
+ */
+export interface HotShotsMixinOptions {
+  /**
+   * Allowlist of logger-context keys to automatically promote to metric tags.
+   * Only scalar (string/number/boolean) context values are promoted; explicit
+   * `.withTags()` tags override derived tags on the same key. The allowlist is
+   * mandatory — context is never auto-promoted wholesale, to avoid
+   * high-cardinality tags (e.g. userId) inflating metric costs.
+   */
+  contextTagKeys?: string[];
+}
+
+/**
  * Builder interface for chaining stats method configurations
  */
 export interface IStatsBuilder {

--- a/packages/mixins/hot-shots/src/types.ts
+++ b/packages/mixins/hot-shots/src/types.ts
@@ -11,6 +11,40 @@ export type StatsCallback = (error?: Error, bytes?: number) => void;
 export type StatsTags = string[] | Record<string, string>;
 
 /**
+ * A structured record of a metric captured by MemoryStatsClient (for testing).
+ */
+export interface StatsRecord {
+  /** The metric operation type */
+  type:
+    | "increment"
+    | "decrement"
+    | "gauge"
+    | "gaugeDelta"
+    | "histogram"
+    | "distribution"
+    | "timing"
+    | "set"
+    | "unique"
+    | "event"
+    | "check"
+    | "timer"
+    | "asyncTimer"
+    | "asyncDistTimer";
+  /** Stat name (or event title / check name) */
+  name: string;
+  /** Metric value; string for set/unique, number|Date for timing, undefined for event */
+  value?: number | string | Date;
+  /** Normalized tag strings, or undefined when none */
+  tags?: string[];
+  /** Sample rate, or undefined */
+  sampleRate?: number;
+  /** DataDog service-check status (check only) */
+  status?: number;
+  /** Event text (event only) */
+  text?: string;
+}
+
+/**
  * Options for configuring the hot-shots mixin.
  */
 export interface HotShotsMixinOptions {


### PR DESCRIPTION
Closes #413

Two independent, opt-in, backward-compatible features for `@loglayer/mixin-hot-shots`.

## Feature 1 — Context-derived tags

Pass an allowlist of context keys to auto-promote to metric tags:

```ts
hotshotsMixin(client, { contextTagKeys: ["endpoint", "method", "status_code"] });

// tagged endpoint:/v1/x automatically, no manual .withTags():
log.withContext({ endpoint: "/v1/x" }).stats.increment("request.count").send();
```

- **Allowlist is mandatory** — only listed keys are promoted (cardinality guard; never auto-promotes `userId`/`reqId`).
- **Scalars only** — `string`/`number`/`boolean`; objects/arrays/null/undefined/missing are skipped.
- **Explicit tags win** — a `.withTags()` tag overrides a derived tag on the same key; no duplicate keys.
- Context is the logger's **resolving** `getContext()` (lazy values resolve), read at `send()` time, on the logger the `.stats` call is made on. AsyncLocalStorage is out of scope (possible follow-up).
- Implemented at the single tag chokepoint (`CommonStatsBuilder.convertTags()`), injected via a one-method `StatsAPI.withContext()` wrapper — all 14 metric types get it for free, no per-builder changes.
- Fully backward compatible: with no `contextTagKeys`, no resolver is created and tag behavior is unchanged.

## Feature 2 — `MemoryStatsClient`

A StatsD-compatible client that records structured metrics for tests instead of parsing StatsD wire format:

```ts
const stats = new MemoryStatsClient();
useLogLayerMixin(hotshotsMixin(stats));
// ...exercise code...
expect(stats.records).toContainEqual({
  type: "increment", name: "dependency.count", value: 1,
  tags: ["dependency:coreApi", "outcome:success"], sampleRate: undefined,
});
stats.clear();
```

- Public `records: StatsRecord[]` + `clear()`; each `.send()` appends exactly one record; a builder never `.send()`-ed records nothing; no network I/O.
- `increment`/`decrement` default value to `1`/`-1`. Note (documented + tested): on increment/decrement a lone `.withSampleRate(r)` is recorded as the `value`, faithful to hot-shots' positional semantics.
- `timer`/`asyncTimer`/`asyncDistTimer` return a wrapper that runs the fn and records a `type: "timer"|"asyncTimer"|"asyncDistTimer"` entry.
- Client param widens to `StatsD | MemoryStatsClient | null`.

## Testing

New `contextTags.test.ts` (allowlist, scalar-only, lazy-resolves-to-scalar, derived-only, explicit-override array+object, no-keys regression) and `memoryStatsClient.test.ts` (record shapes, defaults, tags/sampleRate, sampleRate-as-value pin, no-send, clear, event/check, timer type, and a Feature 1 + Feature 2 compose test). Full monorepo `turbo build && verify-types && test` green (60/60). Changeset added (`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)